### PR TITLE
Added another set of test cases and fixed issues with server/client code

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -169,14 +169,6 @@ class Client extends Base {
     var inputBodyDescriptor = operationDescriptor.input.body;
     var inputHeadersDescriptor = operationDescriptor.input.headers;
 
-    if (operation.style === Operation.Style.documentLiteralWrapped) {
-      // For document literal wrapper style, allow skipping of wrapper element
-      if (args == null || typeof args !== 'object' || !(operation.$name in args)) {
-        let wrapper = {};
-        wrapper[operation.$name] = args;
-        args = wrapper;
-      }
-    }
 
     xmlHandler.jsonToXml(soapBodyElement, nsContext, inputBodyDescriptor, args);
 

--- a/test/server-client-document-test.js
+++ b/test/server-client-document-test.js
@@ -1,0 +1,213 @@
+"use strict";
+
+var fs = require('fs'),
+    soap = require('..').soap,
+    assert = require('assert'),
+    request = require('request'),
+    http = require('http'),
+    lastReqAddress;
+
+
+
+describe('Document style tests', function() {
+
+
+  describe('Document/Literal with simple types param', function() {
+
+    var test = {};
+    test.server = null;
+    test.service = {
+      DocLiteralService: {
+        DocLiteralPort: {
+          myMethod: function(args, cb, soapHeader) {
+            var jsonResponse = {"zElement": true};
+            return jsonResponse;
+          }
+        }
+      }
+    };
+
+    before(function(done) {
+      fs.readFile(__dirname + '/wsdl/strict/doc_literal_test.wsdl', 'utf8', function(err, data) {
+        assert.ok(!err);
+        test.wsdl = data;
+        done();
+      });
+    });
+
+    beforeEach(function(done) {
+      test.server = http.createServer(function(req, res) {
+        res.statusCode = 404;
+        res.end();
+      });
+
+      test.server.listen(15099, null, null, function() {
+        test.soapServer = soap.listen(test.server, '/doc_literal_test', test.service, test.wsdl);
+        test.baseUrl =
+          'http://' + test.server.address().address + ":" + test.server.address().port;
+
+        //windows return 0.0.0.0 as address and that is not
+        //valid to use in a request
+        if (test.server.address().address === '0.0.0.0' || test.server.address().address === '::') {
+          test.baseUrl =
+            'http://127.0.0.1:' + test.server.address().port;
+        }
+
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      test.server.close(function() {
+        test.server = null;
+        delete test.soapServer;
+        test.soapServer = null;
+        done();
+      });
+    });
+
+    //doc/literal with simpleType params test
+    /* In case of doc/literal, client request/response is NOT wrapped inside the operation name. Input and output params are
+    //defined in the schema/xsd. reference - https://www.ibm.com/developerworks/library/ws-whichwsdl/#listing6
+
+    Request
+    <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+     <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Header/>
+        <soap:Body>
+            <xElement>100</xElement>
+            <yElement>10.55</yElement>
+        </soap:Body>
+     </soap:Envelope>
+
+     server response
+     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+     <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Header/>
+          <soap:Body>
+            <zElement>true</zElement>
+          </soap:Body>
+     </soap:Envelope>
+     */
+
+    it('Document/literal test with simpleType params', function(done) {
+      soap.createClient(test.baseUrl + '/doc_literal_test?wsdl', function(err, client) {
+        assert.ok(!err);
+        //see doc_literal_test.wsdl. input message has 2 parts = xElement=int and yElement=float which gets passed as input prams in the client method.
+        client.myMethod( {xElement: 100, yElement: 10.55}, function(err, result, body) {
+          assert.ok(!err);
+          //result is output param which in this case is boolean(zElement) and the server sends 'true' for the value. Since it's wrapped inside the operatioName, result itself is the
+          //output param/output value.
+          assert.ok(result);
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('Document/Literal wrapped with simple type params', function() {
+
+    var test = {};
+    test.server = null;
+    test.service = {
+      DocLiteralWrappedService: {
+        DocLiteralWrappedPort: {
+          myMethod: function(args, cb, soapHeader) {
+            var jsonResponse = {"z": true};
+            return jsonResponse;
+          }
+        }
+      }
+    };
+
+    before(function(done) {
+      fs.readFile(__dirname + '/wsdl/strict/doc_literal_wrapped_test.wsdl', 'utf8', function(err, data) {
+        assert.ok(!err);
+        test.wsdl = data;
+        done();
+      });
+    });
+
+    beforeEach(function(done) {
+      test.server = http.createServer(function(req, res) {
+        res.statusCode = 404;
+        res.end();
+      });
+
+      test.server.listen(15099, null, null, function() {
+        test.soapServer = soap.listen(test.server, '/doc_literal_wrapped_test', test.service, test.wsdl);
+        test.baseUrl =
+          'http://' + test.server.address().address + ":" + test.server.address().port;
+
+        //windows return 0.0.0.0 as address and that is not
+        //valid to use in a request
+        if (test.server.address().address === '0.0.0.0' || test.server.address().address === '::') {
+          test.baseUrl =
+            'http://127.0.0.1:' + test.server.address().port;
+        }
+
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      test.server.close(function() {
+        test.server = null;
+        delete test.soapServer;
+        test.soapServer = null;
+        done();
+      });
+    });
+
+    //doc/literal-wrapped test
+    /* In case of doc/literal-wrapped input params are wrapped inside the wrapper element which should match
+    //the operationName which in the wsdl. Reference - https://www.ibm.com/developerworks/library/ws-whichwsdl/#listing8
+
+    Client Request
+     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+       <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+         <soap:Header/>
+         <soap:Body>
+              <myMethod>
+                 <x>100</x>
+                 <y>10.55</y>
+               </myMethod>
+          </soap:Body>
+        </soap:Envelope>
+
+     Server Response
+     //In Doc/Literal-wrapped, the response  the name of the child of soap:body is, the corresponding wsdl:operation
+     //name suffixed with the string 'Response'." Reference - https://www.ibm.com/developerworks/library/ws-whichwsdl/#listing15
+
+
+     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+          <soap:Header/>
+          <soap:Body>
+            <myMethodResponse>
+              <z>true</z>
+            </myMethodResponse>
+          </soap:Body>
+     </soap:Envelope>
+
+     */
+
+    it('Document/literal wrapped test with simpleType params', function(done) {
+      soap.createClient(test.baseUrl + '/doc_literal_wrapped_test?wsdl', function(err, client) {
+        assert.ok(!err);
+        //
+        client.myMethod( {x: 100, y: 10.55}, function(err, result, body) {
+          assert.ok(!err);
+          //result is the wrapper object which is myMethodResponse which has output param which is the child element. In this test case, server sends 'true' for the output param 'z'.
+          assert.ok(result.z);
+          done();
+        });
+      });
+    });
+
+  });
+
+});
+
+

--- a/test/server-client-rpc-test.js
+++ b/test/server-client-rpc-test.js
@@ -7,34 +7,39 @@ var fs = require('fs'),
     http = require('http'),
     lastReqAddress;
 
-var test = {};
-test.server = null;
-test.service = {
-  StockQuoteServiceRPC: {
-    StockQuotePortRPC: {
-      setLastTradePrice: function(args, cb, soapHeader) {
-      if (args.tradePrice) {
-            var jsonResponse = {"result": true};
-            return jsonResponse;
+
+
+describe('RPC style tests', function() {
+
+
+  describe('RPC Lietral', function() {
+    var test = {};
+    test.server = null;
+    test.service = {
+      StockQuoteServiceRPC: {
+        StockQuotePortRPC: {
+          setLastTradePrice: function(args, cb, soapHeader) {
+            if (args.tradePrice) {
+              var jsonResponse = {"result": true};
+              return jsonResponse;
+            }
+          }
         }
       }
-      }
-    }
-};
+    };
 
-describe('SOAP Server', function() {
-  before(function(done) {
-    fs.readFile(__dirname + '/wsdl/strict/stockquoterpc.wsdl', 'utf8', function(err, data) {
-      assert.ok(!err);
-      test.wsdl = data;
-      done();
+    before(function(done) {
+      fs.readFile(__dirname + '/wsdl/strict/stockquoterpc.wsdl', 'utf8', function(err, data) {
+        assert.ok(!err);
+        test.wsdl = data;
+        done();
+      });
     });
-  });
 
-  beforeEach(function(done) {
-    test.server = http.createServer(function(req, res) {
-      res.statusCode = 404;
-      res.end();
+    beforeEach(function(done) {
+      test.server = http.createServer(function(req, res) {
+        res.statusCode = 404;
+       res.end();
     });
 
     test.server.listen(15099, null, null, function() {
@@ -51,7 +56,9 @@ describe('SOAP Server', function() {
 
       done();
     });
+
   });
+
   afterEach(function(done) {
     test.server.close(function() {
       test.server = null;
@@ -61,10 +68,37 @@ describe('SOAP Server', function() {
     });
   });
 
-  //rpc/literal test
-  it('should return correct results', function(done) {
+    //rpc/literal with complexType input parameters test
+    //In case of rpc/literal client request has operation name which in this case is 'setLastTradePrice'
+    //within it is input parameter.
+    //reference -> https://www.ibm.com/developerworks/library/ws-whichwsdl/#listing4
+    //client request - body
+    /*
+    <soap:Body>
+      <setLastTradePrice>
+        <tradePrice>100</tradePrice>
+      </setLastTradePrice>
+    </soap:Body>
+     */
+
+    //response body
+
+    //"WS-I's Basic Profile dictates that in the RPC/literal response message, the name of the child
+    //of soap:body is has wsdl:operation name suffixed with the string 'Response' which in this test case
+    //is setLastTradePriceResponse" " Reference --> https://www.ibm.com/developerworks/library/ws-whichwsdl/ under
+    //'SOAP response messages' section.
+    /*
+    <soap:Body>
+      <setLastTradePriceResponse>
+        <result>true</result>
+      </setLastTradePriceResponse>
+    </soap:Body>
+    */
+
+  it('RPC Literal with ComplexType test', function(done) {
     soap.createClient(test.baseUrl + '/stockquoterpc?wsdl', function(err, client) {
       assert.ok(!err);
+      //pass in the input param which in this case is complexType param tradePrice
       client.setLastTradePrice( {tradePrice: 100}, function(err, result, body) {
         assert.ok(!err);
         assert.ok(result.result);
@@ -74,3 +108,172 @@ describe('SOAP Server', function() {
   });
 
 });
+
+
+  describe('RPC Literal', function() {
+
+    var test = {};
+    test.server = null;
+    test.service = {
+      RPCLiteralService: {
+        RpcLiteralTestPort: {
+          myMethod: function(args, cb, soapHeader) {
+          }
+        }
+      }
+    };
+
+    before(function(done) {
+      fs.readFile(__dirname + '/wsdl/strict/rpc_literal_test.wsdl', 'utf8', function(err, data) {
+        assert.ok(!err);
+        test.wsdl = data;
+        done();
+      });
+    });
+
+    beforeEach(function(done) {
+      test.server = http.createServer(function(req, res) {
+        res.statusCode = 404;
+        res.end();
+      });
+
+      test.server.listen(15099, null, null, function() {
+        test.soapServer = soap.listen(test.server, '/rpc_literal_test', test.service, test.wsdl);
+        test.baseUrl =
+          'http://' + test.server.address().address + ":" + test.server.address().port;
+
+        //windows return 0.0.0.0 as address and that is not
+        //valid to use in a request
+        if (test.server.address().address === '0.0.0.0' || test.server.address().address === '::') {
+          test.baseUrl =
+            'http://127.0.0.1:' + test.server.address().port;
+        }
+
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      test.server.close(function() {
+        test.server = null;
+        delete test.soapServer;
+        test.soapServer = null;
+        done();
+      });
+    });
+
+    //rpc/literal with simpleType parameters test
+    /* In case of rpc/literal client request is wrapped with operation name which in this case is 'myMethod'
+    //see https://www.ibm.com/developerworks/library/ws-whichwsdl/#listing4
+     <soap:Body>
+        <myMethod>
+          <x>100</x>
+          <y>10.55</y>
+        </myMethod>
+     </soap:Body>
+
+    server response
+    //body="" since this is a one-way request
+    //result (output param inside the body) is null
+    */
+    it('RPC/Literal Simple type test', function(done) {
+      soap.createClient(test.baseUrl + '/rpc_literal_test?wsdl', function(err, client) {
+        assert.ok(!err);
+        //see wsdl. input message has 2 parts = x=int and y=float which gets passed to client method as params.
+        client.myMethod( {x: 100, y: 10.55}, function(err, result, body) {
+          assert.ok(!err);
+          assert.ok(!result);
+          done();
+        });
+      });
+    });
+
+  });
+
+  describe('SOAP Server', function() {
+
+    var test = {};
+    test.server = null;
+    test.service = {
+      RPCEncodedService: {
+        RpcEncodedTestPort: {
+          myMethod: function(args, cb, soapHeader) {
+          }
+        }
+      }
+    };
+
+    before(function(done) {
+      fs.readFile(__dirname + '/wsdl/strict/rpc_encoded_test.wsdl', 'utf8', function(err, data) {
+        assert.ok(!err);
+        test.wsdl = data;
+        done();
+      });
+    });
+
+    beforeEach(function(done) {
+      test.server = http.createServer(function(req, res) {
+        res.statusCode = 404;
+        res.end();
+      });
+
+      test.server.listen(15099, null, null, function() {
+        test.soapServer = soap.listen(test.server, '/rpc_encoded_test', test.service, test.wsdl);
+        test.baseUrl =
+          'http://' + test.server.address().address + ":" + test.server.address().port;
+
+        //windows return 0.0.0.0 as address and that is not
+        //valid to use in a request
+        if (test.server.address().address === '0.0.0.0' || test.server.address().address === '::') {
+          test.baseUrl =
+            'http://127.0.0.1:' + test.server.address().port;
+        }
+
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      test.server.close(function() {
+        test.server = null;
+        delete test.soapServer;
+        test.soapServer = null;
+        done();
+      });
+    });
+
+    //RPC/encoded is not supported by the code currently. Revisit and fix the code to enable this test, when time permits.
+    //What's missing is, in the request/response current code doesn't add xsi:type to x and y parameters in below request.
+    //There is code already to determine if the binding is RPC/encoded.
+
+    //rpc/encoded with simpleType parameters test
+    /* Expected client request envelope
+     //reference https://www.ibm.com/developerworks/library/ws-whichwsdl/#listing2
+     <soap:Body>
+        <myMethod>
+          <x xsi:type="xsd:int">100</x>
+          <y xsi:type="xsd:float">10.55</y>
+        </myMethod>
+     </soap:Body>
+
+     server response
+     //body="" since this is a one-way request
+     //result (data inside the body) is null
+     */
+    it.skip('RPC/Encoded style test', function(done) {
+      soap.createClient(test.baseUrl + '/rpc_encoded_test?wsdl', function(err, client) {
+        assert.ok(!err);
+        //see wsdl. input message has 2 parts = x=int and y=float. Pass them as params.
+        client.myMethod( {x: 100, y: 10.55}, function(err, result, body) {
+          assert.ok(!err);
+          assert.ok(!result);
+          done();
+        });
+      });
+    });
+
+  });
+
+});
+
+

--- a/test/wsdl/strict/doc_literal_test.wsdl
+++ b/test/wsdl/strict/doc_literal_test.wsdl
@@ -1,0 +1,55 @@
+<?xml version="1.0"?>
+
+<wsdl:definitions name="DocLiteral"
+                  targetNamespace="http://example.com/doc_literal_test.wsdl"
+                  xmlns:tns="http://example.com/doc_literal_test.wsdl"
+                  xmlns:xsd1="http://example.com/doc_literal_test.xsd"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/doc_literal_test.xsd"
+                    xmlns:xsd="http://www.w3.org/2000/10/XMLSchema">
+            <xsd:element name="xElement" type="xsd:boolean"/>
+            <xsd:element name="yElement" type="xsd:boolean"/>
+            <xsd:element name="zElement" type="xsd:boolean"/>
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="myMethodRequest">
+        <wsdl:part name="x" element="xsd1:xElement"/>
+        <wsdl:part name="y" element="xsd1:yElement"/>
+    </wsdl:message>
+
+    <wsdl:message name="myMethodResponse">
+        <wsdl:part name="z" element="xsd1:zElement"/>
+    </wsdl:message>
+
+    <wsdl:portType name="DocLiteralPortType">
+        <wsdl:operation name="myMethod">
+            <wsdl:input message="tns:myMethodRequest"/>
+            <wsdl:output message="tns:myMethodResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="DocLiteralBinding" type="tns:DocLiteralPortType">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="myMethod">
+            <soap:operation soapAction="http://example.com/myMethod"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="DocLiteralService">
+        <wsdl:port name="DocLiteralPort" binding="tns:DocLiteralBinding">
+            <soap:address location="http://localhost:15099/doc_literal_test"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/test/wsdl/strict/doc_literal_wrapped_test.wsdl
+++ b/test/wsdl/strict/doc_literal_wrapped_test.wsdl
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+
+<!-- this is document/literal-wrapped style wsdl -->
+
+<wsdl:definitions name="DocLiteralWrapped"
+                  targetNamespace="http://example.com/doc_literal_wrapped_test.wsdl"
+                  xmlns:tns="http://example.com/doc_literal_wrapped_test.wsdl"
+                  xmlns:xsd1="http://example.com/doc_literal_wrapped_test.xsd"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/doc_literal_wrapped_test.xsd"
+                    xmlns:xsd="http://www.w3.org/2000/10/XMLSchema">
+
+            <!-- input complexType name should match the oprtationName for document/literal-wrapped style -->
+            <xsd:element name="myMethod">
+                <xsd:complexType>
+                     <xsd:sequence>
+                        <xsd:element name="x" type="xsd:int"/>
+                        <xsd:element name="y" type="xsd:float"/>
+                     </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+            <!-- as per WS-I, complexType name should be operation name+"Response" in document/literal-wrapped style -->
+            <xsd:element name="myMethodResponse">
+                <xsd:complexType>
+                    <xsd:sequence>
+                        <xsd:element name="z" type="xsd:boolean"/>
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:element>
+
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="myMethodRequest">
+        <wsdl:part name="parameters" element="xsd1:myMethod"/>
+    </wsdl:message>
+
+    <wsdl:message name="myMethodResponse">
+        <wsdl:part name="parameters" element="xsd1:myMethodResponse"/>
+    </wsdl:message>
+
+    <wsdl:portType name="DocLiteralWrappedPortType">
+        <wsdl:operation name="myMethod">
+            <wsdl:input message="tns:myMethodRequest"/>
+            <wsdl:output message="tns:myMethodResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="DocLiteralWrappedBinding" type="tns:DocLiteralWrappedPortType">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="myMethod">
+            <soap:operation soapAction="http://example.com/myMethod"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="DocLiteralWrappedService">
+        <wsdl:port name="DocLiteralWrappedPort" binding="tns:DocLiteralWrappedBinding">
+            <soap:address location="http://localhost:15099/doc_literal_wrapped_test"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>

--- a/test/wsdl/strict/rpc_encoded_test.wsdl
+++ b/test/wsdl/strict/rpc_encoded_test.wsdl
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!-- rpc/encoded example -->
+
+<wsdl:definitions name="StockQuoteRPCEncoded"
+                  targetNamespace="http://example.com/rpc_encoded_test.wsdl"
+                  xmlns:tns="http://example.com/rpc_encoded_test.wsdl"
+                  xmlns:xsd1="http://example.com/rpc_encoded_test.xsd"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2000/10/XMLSchema">
+
+    <wsdl:message name="myMethodRequest">
+        <wsdl:part name="x" type="xsd:int"/>
+        <wsdl:part name="y" type="xsd:float"/>
+    </wsdl:message>
+
+
+    <wsdl:portType name="RPCEncodedTest">
+        <wsdl:operation name="myMethod">
+            <wsdl:input message="tns:myMethodRequest"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+
+    <wsdl:binding name="RPCEncodedTestBinding" type="tns:RPCEncodedTest">
+        <soap:binding style="rpc"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="myMethod">
+            <soap:operation soapAction="http://example.com/RPCEncodedTest"/>
+            <wsdl:input>
+                <soap:body/>
+            </wsdl:input>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="RPCEncodedService">
+        <wsdl:port name="RpcEncodedTestPort" binding="tns:RPCEncodedTestBinding">
+            <soap:address location="http://localhost:15099/rpc_Encoded_testing"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>
+

--- a/test/wsdl/strict/rpc_literal_test.wsdl
+++ b/test/wsdl/strict/rpc_literal_test.wsdl
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!-- rpc/literal example -->
+
+<wsdl:definitions name="StockQuoteRPC"
+                  targetNamespace="http://example.com/rpc_literal_test.wsdl"
+                  xmlns:tns="http://example.com/rpc_literal_test.wsdl"
+                  xmlns:xsd1="http://example.com/rpc_literal_test.xsd"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2000/10/XMLSchema">
+
+    <wsdl:message name="myMethodRequest">
+        <wsdl:part name="x" type="xsd:int"/>
+        <wsdl:part name="y" type="xsd:float"/>
+    </wsdl:message>
+
+
+    <wsdl:portType name="RPCLiteralTest">
+        <wsdl:operation name="myMethod">
+            <wsdl:input message="tns:myMethodRequest"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+
+    <wsdl:binding name="RPCLiteralTestBinding" type="tns:RPCLiteralTest">
+        <soap:binding style="rpc"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="myMethod">
+            <soap:operation soapAction="http://example.com/RPCLiteralTest"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="RPCLiteralService">
+        <wsdl:port name="RpcLiteralTestPort" binding="tns:RPCLiteralTestBinding">
+            <soap:address location="http://localhost:15099/rpc_literal_testing"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>
+

--- a/test/wsdl/strict/stockquoterpc.wsdl
+++ b/test/wsdl/strict/stockquoterpc.wsdl
@@ -3,49 +3,46 @@
 <!-- rpc/literal example -->
 
 <wsdl:definitions name="StockQuoteRPC"
-                  targetNamespace="http://example.com/stockquoterpc.wsdl"
-                  xmlns:tns="http://example.com/stockquoterpc.wsdl"
+
                   xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://example.com/stockquoterpc.wsdl"
+                  targetNamespace="http://example.com/stockquoterpc.wsdl"
                   xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+    <wsdl:types>
+    <xsd:schema elementFormDefault="qualified"
+              targetNamespace="http://example.com/stockquoterpc.wsdl">
 
-<wsdl:types>
-    <xsd:schema targetNamespace="http://example.com/stockquoterpc.xsd"
-                xmlns:xsd="http://www.w3.org/2000/10/XMLSchema" xmlns="http://example.com/stockquoterpc.xsd" elementFormDefault="qualified">
 
-            <xsd:element name="setLastTradePriceRequest" type="setLastTradePriceResponseType"/>
-            <xsd:element name="setLastTradePriceResponseType">
-                <xsd:complexType>
+                <xsd:complexType name="setLastTradePriceRequestType">
                     <xsd:sequence>
                         <xsd:element name="tradePrice" type="xsd:float"/>
                     </xsd:sequence>
                 </xsd:complexType>
-            </xsd:element>
 
-            <xsd:element name="setLastTradePriceResponse" type="setLastTradePriceResponseType"/>
-            <xsd:element name="setLastTradePriceResponseType">
-                <xsd:complexType>
+                <xsd:complexType name="setLastTradePriceResponseType">
                     <xsd:sequence>
                         <xsd:element name="result" type="xsd:boolean"/>
                     </xsd:sequence>
                 </xsd:complexType>
-            </xsd:element>
+
         </xsd:schema>
     </wsdl:types>
 
 
-    <wsdl:message name="setLastTradePriceRequest">
+    <wsdl:message name="myRequest">
         <wsdl:part name="tradePrice"
-              type="xsd:float"/>
+              type="tns:setLastTradePriceRequestType"/>
     </wsdl:message>
-    <wsdl:message name="setLastTradePriceResponse">
+    <wsdl:message name="myResponse">
         <wsdl:part name="result"
-              type="xsd:boolean"/>
+              type="tns:setLastTradePriceResponseType"/>
     </wsdl:message>
 
     <wsdl:portType name="StockQuoteUpdater">
         <wsdl:operation name="setLastTradePrice">
-            <wsdl:input message="tns:setLastTradePriceRequest"/>
-            <wsdl:output message="tns:setLastTradePriceResponse"/>
+            <wsdl:input message="tns:myRequest"/>
+            <wsdl:output message="tns:myResponse"/>
         </wsdl:operation>
     </wsdl:portType>
 


### PR DESCRIPTION
1)  Fixed Client.js - removed logic to wrap operationName for DocLitWrapped case since the code already does it in another point of execution.
2) Fixed server.js - while calculating outputName, code assumed that there is a 'part' with the name "body" which is incorrect.
3) Added RPC/Literal test with complex type params 
4) Added RPC/Literal test with simple type params
5) Added RPC/encoded test (skipped for now)
6) Added Document/Literal test 
7) Added Document/Lietral-wrapped test
8) Added detail comments for each of the test case above with the actual input/output env

@raymondfeng PTAL