### PR TITLE
Remove and re-implement forceSoap12Headers wsdl option

### DIFF
--- a/example/weather.js
+++ b/example/weather.js
@@ -23,8 +23,11 @@ soap.createClient(url, clientOptions, function(err, client) {
   //custom request header
   var customRequestHeader = {timeout: 5000};
   var options = {};
+  //navigate to the correct operation in the client using [service][port][operation] since GetCityWeatherByZIP operation is used
+  //by more than one port.
+  var method = client['Weather']['WeatherSoap']['GetCityWeatherByZIP'];
   //you can also call
-  client.GetCityWeatherByZIP(requestArgs, function(err, result, envelope, soapHeader) {
+  method(requestArgs, function(err, result, envelope, soapHeader) {
     //response envelope
     console.log(envelope);
     //result in SOAP envelope body which is the wrapper element. In this case, result object corresponds to GetCityForecastByZIPResponse

--- a/example/xsds.js
+++ b/example/xsds.js
@@ -10,7 +10,7 @@ WSDL.open('./wsdls/weather.wsdl', options,
   //User can traverse the WSDL tree and get to bindings - > operations, services, portTypes, messages, parts and XSD elements/Attributes
   function(err, wsdl) {
     var getCityForecastOp = wsdl.definitions.bindings.WeatherSoap.operations.GetCityForecastByZIP;
-    console.log(getCityForecastOp.name);
+    console.log(getCityForecastOp.$name);
     var service = wsdl.definitions.services['Weather'];
-    console.log(service.name);;
+    console.log(service.$name);
   });

--- a/src/base.js
+++ b/src/base.js
@@ -58,7 +58,6 @@ class Base extends EventEmitter {
     options = options || {};
     this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
     this.wsdl.options.envelopeKey = options.envelopeKey || 'soap';
-    this.wsdl.options.forceSoap12Headers = !!options.forceSoap12Headers;
   }
 
   static createSOAPEnvelope(prefix, nsURI) {

--- a/src/client.js
+++ b/src/client.js
@@ -120,7 +120,7 @@ class Client extends Base {
     var soapNsURI = 'http://schemas.xmlsoap.org/soap/envelope/';
     var soapNsPrefix = this.wsdl.options.envelopeKey || 'soap';
 
-    if (this.wsdl.options.forceSoap12Headers) {
+    if (operation.soapVersion === '1.2') {
       headers['Content-Type'] = 'application/soap+xml; charset=utf-8';
       soapNsURI = 'http://www.w3.org/2003/05/soap-envelope';
     }
@@ -133,7 +133,7 @@ class Client extends Base {
       soapAction = ((ns.lastIndexOf("/") !== ns.length - 1) ? ns + "/" : ns) + name;
     }
 
-    if (!this.wsdl.options.forceSoap12Headers) {
+    if (operation.soapVersion !== '1.2') {
       headers.SOAPAction = '"' + soapAction + '"';
     }
 

--- a/src/parser/wsdl.js
+++ b/src/parser/wsdl.js
@@ -139,10 +139,6 @@ class WSDL {
       this.options.ignoreBaseNameSpaces = ignoreBaseNameSpaces;
     else
       this.options.ignoreBaseNameSpaces = this.ignoreBaseNameSpaces;
-
-    // Works only in client
-    this.options.forceSoap12Headers = options.forceSoap12Headers;
-
   }
 
   _processNextInclude(includes, callback) {

--- a/src/parser/wsdl/operation.js
+++ b/src/parser/wsdl/operation.js
@@ -211,9 +211,9 @@ class Operation extends WSDLElement {
       }
     };
     this.descriptor.inputEnvelope =
-      Operation.createEnvelopeDescriptor(this.descriptor.input, false);
+      Operation.createEnvelopeDescriptor(this.descriptor.input, false, this.soapVersion);
     this.descriptor.outputEnvelope =
-      Operation.createEnvelopeDescriptor(this.descriptor.output, true);
+      Operation.createEnvelopeDescriptor(this.descriptor.output, true, this.soapVersion);
     this.descriptor.faultEnvelope =
       Operation.createEnvelopeDescriptor(this.descriptor.faults, true, this.soapVersion);
 
@@ -222,7 +222,14 @@ class Operation extends WSDLElement {
 
   static createEnvelopeDescriptor(parameterDescriptor, isOutput, soapVersion, prefix, nsURI) {
     prefix = prefix || 'soap';
-    nsURI = nsURI || 'http://schemas.xmlsoap.org/soap/envelope/';
+    var soapNsURI;
+    if (soapVersion === '1.1') {
+      soapNsURI = 'http://schemas.xmlsoap.org/soap/envelope/';
+    } else if (soapVersion === '1.2') {
+      soapNsURI = 'http://www.w3.org/2003/05/soap-envelope';
+    }
+
+    nsURI = nsURI || soapNsURI;
     var descriptor = new TypeDescriptor();
 
     var envelopeDescriptor = new ElementDescriptor(

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -278,7 +278,7 @@ class XMLHandler {
       {version: '1.0', encoding: 'UTF-8', standalone: true});
     nsURI = nsURI || 'http://schemas.xmlsoap.org/soap/envelope/'
     doc.attribute('xmlns:' + prefix,
-      'http://schemas.xmlsoap.org/soap/envelope/');
+      nsURI);
     let header = doc.element(prefix + ':Header');
     let body = doc.element(prefix + ':Body');
     return {

--- a/src/server.js
+++ b/src/server.js
@@ -299,8 +299,7 @@ class Server extends Base {
       var soapNsURI = 'http://schemas.xmlsoap.org/soap/envelope/';
       var soapNsPrefix = self.wsdl.options.envelopeKey || 'soap';
 
-      if (self.wsdl.options.forceSoap12Headers) {
-        headers['Content-Type'] = 'application/soap+xml; charset=utf-8';
+      if (operation.soapVersion === '1.2') {
         soapNsURI = 'http://www.w3.org/2003/05/soap-envelope';
       }
 
@@ -375,7 +374,6 @@ class Server extends Base {
       error.Fault.statusCode = undefined;
     }
 
-    var env = XMLHandler.createSOAPEnvelope();
     var operationDescriptor = operation.describe(this.wsdl.definitions);
     //get envelope descriptor
     var faultEnvDescriptor = operation.descriptor.faultEnvelope.elements[0];
@@ -383,8 +381,7 @@ class Server extends Base {
     var soapNsURI = 'http://schemas.xmlsoap.org/soap/envelope/';
     var soapNsPrefix = self.wsdl.options.envelopeKey || 'soap';
 
-    if (self.wsdl.options.forceSoap12Headers) {
-      headers['Content-Type'] = 'application/soap+xml; charset=utf-8';
+    if (operation.soapVersion === '1.2') {
       soapNsURI = 'http://www.w3.org/2003/05/soap-envelope';
     }
 
@@ -399,11 +396,11 @@ class Server extends Base {
     var faultDescriptor = bodyDescriptor.elements[0];
 
     //serialize Fault object into XML as per faultDescriptor
-    this.xmlHandler.jsonToXml(env.body, nsContext, faultDescriptor, error.Fault);
+    this.xmlHandler.jsonToXml(envelope.body, nsContext, faultDescriptor, error.Fault);
 
-    self._envelope(env, includeTimestamp);
-    var message = env.body.toString({pretty: true});
-    var xml = env.doc.end({pretty: true});
+    self._envelope(envelope, includeTimestamp);
+    var message = envelope.body.toString({pretty: true});
+    var xml = envelope.doc.end({pretty: true});
 
     callback(xml, statusCode);
   }

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -313,11 +313,11 @@ describe('SOAP Client', function() {
     });
 
     it('should add proper headers for soap12', function(done) {
-      soap.createClient(__dirname+'/wsdl/default_namespace_soap12.wsdl', {forceSoap12Headers: true}, function(err, client) {
+      soap.createClient(__dirname+'/wsdl/default_namespace_soap12.wsdl', function(err, client) {
         assert.ok(client);
         assert.ok(!err);
 
-        client.MyOperation({}, function(err, result) {
+        client.MyOperation({}, function(err, result, envelope) {
           assert.ok(result);
           assert.ok(client.lastRequestHeaders);
           assert.ok(client.lastRequest);

--- a/test/request-response-samples-test.js
+++ b/test/request-response-samples-test.js
@@ -133,7 +133,20 @@ function generateTest(name, methodName, wsdlPath, headerJSON, securityJSON, requ
       if (securityJSON && securityJSON.type === 'ws') {
         client.setSecurity(new WSSecurity(securityJSON.username, securityJSON.password, securityJSON.options));
       }
-      client[methodName](requestJSON, function(err, json, body, soapHeader){
+      //For the test cases with  method names  'addPets'/'GetAccountXML'/'GetNodes', the corresponding wsdls(see soap.wsdl in corresponding sub directories) has 2 wsdl ports/2 bindings pointing to
+      //same operation e.g addPets(). The correct way to invoke operation in this case is  to pick the operation to be invoked using 'client['Service1']['Service1Soap']['addPets'].
+      var method;
+      if (methodName === 'addPets') { //use soap 1.1 binding operation
+        method = client ['Service1']['Service1Soap'][methodName];
+      } else if (methodName === 'GetNodes') {//use soap 1.2 binding operation
+        method = client ['Service1']['Service1Soap12'][methodName];
+      } else if (methodName === 'GetAccountXML' ) {//use 1.2 binding operation
+        method = client ['Service1']['Service1Soap12'][methodName];
+      } else { //rest of the tests which has unique operation
+        method = client[methodName];
+      }
+
+      method(requestJSON, function(err, json, body, soapHeader){
         if(requestJSON){
           if (err) {
             assert.notEqual('undefined: undefined', err.message);

--- a/test/request-response-samples/GetAccountXml__non_xmlns_attributes_should_be_returned/request.xml
+++ b/test/request-response-samples/GetAccountXml__non_xmlns_attributes_should_be_returned/request.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
 <soap:Header/>
 <soap:Body>
 <ns1:GetAccountXml xmlns:ns1="#Foo">

--- a/test/request-response-samples/GetAccountXml__non_xmlns_attributes_should_be_returned/response.xml
+++ b/test/request-response-samples/GetAccountXml__non_xmlns_attributes_should_be_returned/response.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <soap:Envelope
-  xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"
+  xmlns:soap="http://www.w3.org/2003/05/soap-envelope"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <soap:Body>

--- a/test/request-response-samples/GetNodes__complex_self_referencing/request.xml
+++ b/test/request-response-samples/GetNodes__complex_self_referencing/request.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
 <soap:Header/>
 <soap:Body>
 		<ns1:GetNodes xmlns:ns1="http://tempuri.org/"/>

--- a/test/request-response-samples/GetNodes__complex_self_referencing/response.xml
+++ b/test/request-response-samples/GetNodes__complex_self_referencing/response.xml
@@ -1,4 +1,4 @@
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 	<soap:Body>
 		<GetNodesResponse xmlns="http://tempuri.org/">
 			<GetNodesResult>

--- a/test/server-client-document-test.js
+++ b/test/server-client-document-test.js
@@ -523,14 +523,14 @@ describe('Document style tests', function() {
 
      Client Request
      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-     <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-      <soap:Header/>
-      <soap:Body>
-        <myMethod>
-          <x>200</x>
-          <y>10.55</y>
-        </myMethod>
-      </soap:Body>
+     <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header/>
+        <soap:Body>
+          <ns1:myMethod xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.wsdl">
+            <x>200</x>
+            <y>10.55</y>
+          </ns1:myMethod>
+        </soap:Body>
      </soap:Envelope>
 
      Server Response
@@ -538,27 +538,27 @@ describe('Document style tests', function() {
      //and also the response envelope should contain <Fault> and <Detailt> element should contain element <myMethodFault> defined in the wsdl
 
      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-     <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-      <soap:Header/>
-      <soap:Body>
-        <soap:Fault>
-          <soap:Code>
-            <soap:Value>soap:Sender</soap:Value>
-            <soap:Subcode>
-              <soap:Value>rpc:BadArguments</soap:Value>
-            </soap:Subcode>
-          </soap:Code>
-          <soap:Reason>
-            <soap:Text>Processing Error</soap:Text>
-          </soap:Reason>
-          <soap:Detail>
-            <ns1:myMethodFault2 xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.wsdl">
-                <errorMessage2>MyMethod Business Exception message</errorMessage2>
-                <value2>10</value2>
-            </ns1:myMethodFault2>
-          </soap:Detail>
-         </soap:Fault>
-     </soap:Body>
+     <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+       <soap:Header/>
+        <soap:Body>
+          <soap:Fault>
+            <soap:Code>
+              <soap:Value>soap:Sender</soap:Value>
+              <soap:Subcode>
+                <soap:Value>rpc:BadArguments</soap:Value>
+              </soap:Subcode>
+            </soap:Code>
+            <soap:Reason>
+              <soap:Text>Processing Error</soap:Text>
+            </soap:Reason>
+            <soap:Detail>
+                <ns1:myMethodFault2 xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.wsdl">
+                    <errorMessage2>MyMethod Business Exception message</errorMessage2>
+                    <value2>10</value2>
+                </ns1:myMethodFault2>
+            </soap:Detail>
+          </soap:Fault>
+        </soap:Body>
      </soap:Envelope>
 
      */


### PR DESCRIPTION
- Removed wsdl option 'forceSoap12Headers' setting. Added code to figure out if the request, response   
   and fault envelope should use soap 1.1 or soap 1.2 based on the binding from the WSDL.
- Fixed request/response/fault path.
- Fixed tests to invoke correct operation if multiple bindings point to same operation.
- Fixed 1.2 to show correct soap 1.2 namespace in request/response/fault.
- Cleanup of examples with minor fixes.

@raymondfeng PTAL