### PR TITLE
add babel script as prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "cover": "istanbul cover _mocha -- --timeout 10000 test/*-test.js test/security/*.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls -v",
     "test": "mocha --timeout 10000 test/*-test.js test/security/*.js",
-    "pretest": "babel src -d lib"
+    "pretest": "babel src -d lib",
+    "prepublish": "babel src -d lib"
   },
   "keywords": [
     "soap"


### PR DESCRIPTION
fix to add babel as npm prepublish to compile es6