### PR TITLE
Using targetNamespace of the attribute if present

### DIFF
--- a/src/parser/element.js
+++ b/src/parser/element.js
@@ -86,7 +86,7 @@ class Element {
     if (ElementType) {
       child = new ElementType(nsName, attrs, options);
       child.nsURI = qname.nsURI;
-      child.targetNamespace = this.getTargetNamespace();
+      child.targetNamespace = attrs.targetNamespace || this.getTargetNamespace();
       debug('Element created: ', child);
       child.parent = parent;
       stack.push(child);

--- a/test/client-customHttp-xsdinclude-test.js
+++ b/test/client-customHttp-xsdinclude-test.js
@@ -83,11 +83,11 @@ describe('custom http client', function() {
           assert.equal(myOp.soapAction, 'tns#Dummy');
 
           var reqElement = myOp.input.body.elements[0].qname;
-          assert.equal(reqElement.nsURI, 'http://www.dummy.com');
+          assert.equal(reqElement.nsURI, 'http://www.dummy.com/Types');
           assert.equal(reqElement.name, 'DummyRequest');
 
           var resElement = myOp.output.body.elements[0].qname;
-          assert.equal(resElement.nsURI, 'http://www.dummy.com');
+          assert.equal(resElement.nsURI, 'http://www.dummy.com/Types');
           assert.equal(resElement.name, 'DummyResponse');
 
           done();

--- a/test/request-response-samples/SendCDATA__cdata_is_handled_correctly/request.xml
+++ b/test/request-response-samples/SendCDATA__cdata_is_handled_correctly/request.xml
@@ -2,7 +2,7 @@
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
 <soap:Header/>
 <soap:Body>
-    <ns1:TestMessage xmlns:ns1="http://example.com/testservice.wsdl">
+    <ns1:TestMessage xmlns:ns1="http://example.com/testservice.xsd">
       <message><![CDATA[Hello World! & Hello Me!]]></message>
     </ns1:TestMessage>
 </soap:Body>

--- a/test/request-response-samples/administrate__Complex_json_object_namespace_issue/request.xml
+++ b/test/request-response-samples/administrate__Complex_json_object_namespace_issue/request.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
 <soap:Header/><soap:Body>
-<ns1:Administrate xmlns:ns1="http://schemas.My.com/My11/wsdl">
+<ns1:Administrate xmlns:ns1="http://schemas.My.com/My11">
 <ns1:AdminOperation>
 <ns1:CreateUser>
 <ns1:User><ns1:Name>name</ns1:Name>

--- a/test/server-client-document-test.js
+++ b/test/server-client-document-test.js
@@ -577,7 +577,7 @@ describe('Document style tests', function() {
           //check if fault exists with correct 'Detail' parameters in the response
           var index = body.indexOf('<soap:Detail>');
           assert.ok(index > -1);
-          var index = body.indexOf('ns1:myMethodFault2 xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.wsdl"');
+          var index = body.indexOf('ns1:myMethodFault2 xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.xsd"');
           assert.ok(index > -1);
           var index = body.indexOf('<errorMessage2>MyMethod Business Exception message</errorMessage2>');
           assert.ok(index > -1);

--- a/test/server-options-test.js
+++ b/test/server-options-test.js
@@ -158,7 +158,7 @@ describe('SOAP Server with Options', function() {
   
   
   it('should return correct stock price in response body', function(done) {
-    var responseData = '<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Header/>\n  <soap:Body>\n    <ns1:TradePrice xmlns:ns1=\"http://example.com/stockquote.wsdl\">\n      <price>19.56</price>\n    </ns1:TradePrice>\n  </soap:Body>\n</soap:Envelope>';
+    var responseData = '<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Header/>\n  <soap:Body>\n    <ns1:TradePrice xmlns:ns1=\"http://example.com/stockquote.xsd\">\n      <price>19.56</price>\n    </ns1:TradePrice>\n  </soap:Body>\n</soap:Envelope>';
     test.server.listen(15099, null, null, function() {
       test.soapServer = soap.listen(test.server, {
         path: '/stockquote',


### PR DESCRIPTION
This is what fixes the namespace problem for the web services I consume. I think it's the right thing to do since the targetNamespace of the schema containing the requests and responses should be used for those too (if they don't specify another one, though).