### PR TITLE
'definitions' not available in describeHeaders () function

### DIFF
--- a/src/parser/wsdl/operation.js
+++ b/src/parser/wsdl/operation.js
@@ -64,7 +64,7 @@ class Operation extends WSDLElement {
     this._processed = true;
   }
 
-  static describeHeaders(param) {
+  static describeHeaders(param, definitions) {
     if (param == null) return null;
     var headers = new descriptor.TypeDescriptor();
     if (!param.headers) return headers;
@@ -190,8 +190,8 @@ class Operation extends WSDLElement {
     }
 
     let faults = this.describeFaults(definitions);
-    let inputHeaders = Operation.describeHeaders(this.input);
-    let outputHeaders = Operation.describeHeaders(this.output);
+    let inputHeaders = Operation.describeHeaders(this.input, definitions);
+    let outputHeaders = Operation.describeHeaders(this.output, definitions);
 
     this.descriptor = {
       name: this.$name,

--- a/test/wsdl/strict/doc_literal_wrapped_test.wsdl
+++ b/test/wsdl/strict/doc_literal_wrapped_test.wsdl
@@ -85,6 +85,7 @@
         <wsdl:operation name="myMethod">
             <soap:operation soapAction="http://example.com/myMethod"/>
             <wsdl:input>
+                <soap:header message="tns:myMethodRequest" part="parameters" use="literal"></soap:header>
                 <soap:body use="literal"/>
             </wsdl:input>
             <wsdl:output>


### PR DESCRIPTION
Fixes issue #31  Fix is in operation.js where code passes in 'definitions' to describeHeaders() function.

@raymondfeng PTAL