### PR TITLE
Initial support for NTLM

### DIFF
--- a/example/ntlm.js
+++ b/example/ntlm.js
@@ -20,12 +20,13 @@ var requestArgs = {
   ZIP: '94306'
 };
 
+//FILL_IN
 var username = "fill_in";
 var password = "fill_in";
 var domain = "fill_in";
 var workstation = "fill_in";
 
-var ntlmSecurity = new NTLMSecurity(username);
+var ntlmSecurity = new NTLMSecurity(username, password, domain, workstation);
 var clientOptions = {};
 clientOptions.NTLMSecurity = ntlmSecurity;
 

--- a/example/ntlm.js
+++ b/example/ntlm.js
@@ -1,0 +1,47 @@
+
+"use strict";
+
+var fs = require('fs');
+var assert = require('assert');
+var request = require('request');
+var http = require('http');
+var lastReqAddress;
+var soap = require('..').soap;
+var XMLHandler = soap.XMLHandler;
+var xmlHandler = new XMLHandler();
+var util = require('util');
+var NTLMSecurity = require('..').NTLMSecurity;
+
+//wsdl of the NTLM authenticated Web Service this client is going to invoke.
+var url = 'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL';
+//JSON request
+var requestArgs = {
+  //Fill in based on your wsdl
+  ZIP: '94306'
+};
+
+var username = "fill_in";
+var password = "fill_in";
+var domain = "fill_in";
+var workstation = "fill_in";
+
+var ntlmSecurity = new NTLMSecurity(username);
+var clientOptions = {};
+clientOptions.NTLMSecurity = ntlmSecurity;
+
+soap.createClient(url, clientOptions, function(err, client) {
+  var service = 'service_name';
+  var port = 'port_name';
+  var operation = 'operation_name';
+  //navigate to the correct operation in the client using [service][port][operation] since GetCityWeatherByZIP operation is used
+  //by more than one port.
+  var method = client[service][port][operation];
+
+  //you can also call
+  method(requestArgs, function(err, result, envelope, soapHeader) {
+    console.log('Response envelope:');
+    //response envelope
+    console.log(envelope);
+
+  }, null, null);
+});

--- a/example/ntlm.js
+++ b/example/ntlm.js
@@ -12,8 +12,11 @@ var xmlHandler = new XMLHandler();
 var util = require('util');
 var NTLMSecurity = require('..').NTLMSecurity;
 
+//example to show how to authenticate
+
 //wsdl of the NTLM authenticated Web Service this client is going to invoke.
-var url = 'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL';
+//var url = 'http://wsf.cdyne.com/WeatherWS/Weather.asmx?WSDL';
+var url = './wsdls/weather.wsdl';
 //JSON request
 var requestArgs = {
   //Fill in based on your wsdl
@@ -25,10 +28,13 @@ var username = "fill_in";
 var password = "fill_in";
 var domain = "fill_in";
 var workstation = "fill_in";
+//change it to 'false' or don't set this param, if you don't want WSDL 'GET' from remote NTLM webservice doesn't require NTLM authentication
+var wsdlAuthRequired = true;
 
-var ntlmSecurity = new NTLMSecurity(username, password, domain, workstation);
+var ntlmSecurity = new NTLMSecurity(username, password, domain, workstation, wsdlAuthRequired);
 var clientOptions = {};
 clientOptions.NTLMSecurity = ntlmSecurity;
+
 
 soap.createClient(url, clientOptions, function(err, client) {
   var service = 'service_name';

--- a/example/ntlm.js
+++ b/example/ntlm.js
@@ -31,7 +31,9 @@ var workstation = "fill_in";
 //change it to 'false' or don't set this param, if you don't want WSDL 'GET' from remote NTLM webservice doesn't require NTLM authentication
 var wsdlAuthRequired = true;
 
+
 var ntlmSecurity = new NTLMSecurity(username, password, domain, workstation, wsdlAuthRequired);
+
 var clientOptions = {};
 clientOptions.NTLMSecurity = ntlmSecurity;
 

--- a/example/ntlm.js
+++ b/example/ntlm.js
@@ -30,10 +30,7 @@ var domain = "fill_in";
 var workstation = "fill_in";
 //change it to 'false' or don't set this param, if you don't want WSDL 'GET' from remote NTLM webservice doesn't require NTLM authentication
 var wsdlAuthRequired = true;
-
-
 var ntlmSecurity = new NTLMSecurity(username, password, domain, workstation, wsdlAuthRequired);
-
 var clientOptions = {};
 clientOptions.NTLMSecurity = ntlmSecurity;
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "selectn": "^1.0.20",
     "strong-globalize": "^2.8.0",
     "xml-crypto": "^0.8.4",
-    "xmlbuilder": "^8.2.2"
+    "xmlbuilder": "^8.2.2",
+    "httpntlm": "^1.6.1"
   },
   "optionalDependencies": {
     "ursa": "^0.9.4"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "compress": "^0.99.0",
     "debug": "^2.2.0",
     "lodash": "^4.13.1",
-    "node-uuid": "^1.4.7",
+    "uuid": "^3.0.0",
     "optional": "^0.1.3",
     "path": "^0.12.7",
     "request": "^2.72.0",

--- a/src/client.js
+++ b/src/client.js
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2011 Vinay Pulim <vinay@milewise.com>
- * MIT Licensed
- */
-
 'use strict';
 
 var g = require('./globalize');

--- a/src/client.js
+++ b/src/client.js
@@ -321,7 +321,9 @@ class Client extends Base {
     }, headers, options, self);
 
     // Added mostly for testability, but possibly useful for debugging
-    self.lastRequestHeaders = req.headers;
+    if (req != null) {
+      self.lastRequestHeaders = req.headers;
+    }
     debug('client response. lastRequestHeaders: %j', self.lastRequestHeaders);
   }
 }

--- a/src/http.js
+++ b/src/http.js
@@ -126,12 +126,13 @@ class HttpClient {
       options.password = ntlmSecurity.password;
       options.domain = ntlmSecurity.domain;
       options.workstation = ntlmSecurity.workstation;
-      var method = options.method;
-      req = httpntlm['method'](method, options, function (err, res, body) {
+      //httpntlm code uses lower case for method names - 'get', 'post' etc
+      var method = options.method.toLocaleLowerCase();
+      req = httpntlm['method'](method, options, function (err, res) {
         if (err) {
           return callback(err);
         }
-        body = self.handleResponse(req, res, body);
+        var body = self.handleResponse(req, res, body);
         callback(null, res, body);
       });
     }

--- a/src/http.js
+++ b/src/http.js
@@ -3,6 +3,7 @@
 var url = require('url');
 var req = require('request');
 var debug = require('debug')('st-soap:http');
+var httpntlm = require('httpntlm');
 
 var VERSION = require('../package.json').version;
 
@@ -15,7 +16,7 @@ var VERSION = require('../package.json').version;
  */
 class HttpClient {
   constructor(options) {
-    options = options || {};
+    this.options = options || {};
     this._request = options.request || req;
   }
 
@@ -104,13 +105,36 @@ class HttpClient {
     var self = this;
     var options = self.buildRequest(rurl, data, exheaders, exoptions);
     var headers = options.headers;
-    var req = self._request(options, function(err, res, body) {
+    var req;
+
+    //typically clint.js would do addOptions() if security is set to get all security options added to options{}. But client.js
+    //addoptions() code runs after this code is trying to contact server to load remote WSDL, hence we would NTLM authentication
+    //object passed in as option to createClient( ) call for now. Revisit.
+    var ntlmSecurity = this.options.NTLMSecurity;
+    if (ntlmSecurity == null) {
+      req = self._request(options, function (err, res, body) {
       if (err) {
         return callback(err);
       }
       body = self.handleResponse(req, res, body);
       callback(null, res, body);
     });
+    } else {
+      //NTLMSecurity code needs 'url' in options{} and it should be plain string, not parsed uri
+      options.url = rurl;
+      options.username = ntlmSecurity.username;
+      options.password = ntlmSecurity.password;
+      options.domain = ntlmSecurity.domain;
+      options.workstation = ntlmSecurity.workstation;
+      var method = options.method;
+      req = httpntlm['method'](method, options, function (err, res, body) {
+        if (err) {
+          return callback(err);
+        }
+        body = self.handleResponse(req, res, body);
+        callback(null, res, body);
+      });
+    }
 
     return req;
   }

--- a/src/http.js
+++ b/src/http.js
@@ -87,7 +87,7 @@ class HttpClient {
    * @param {Object} body The http body
    * @param {Object} The parsed body
    */
-  handleResponse(req, res, body) {
+  handleResponse(body) {
     debug('Http response body: %j', body);
     if (typeof body === 'string') {
       // Remove any extra characters that appear before or after the SOAP
@@ -101,41 +101,55 @@ class HttpClient {
     return body;
   }
 
+  //check if NTLM authentication needed
+  isNtlmAuthRequired(ntlmSecurity, methodName) {
+    //if ntlmSecurity is not set, then remote web service is not NTLM authenticated Web Service
+    if (ntlmSecurity == null) {
+      return false;
+    } else if (methodName === 'GET' && (ntlmSecurity.wsdlAuthRequired == null || ntlmSecurity.wsdlAuthRequired === false)) {
+      //In some WebServices, getting remote WSDL is not NTLM authenticated. Only WebService invocation is NTLM authenticated.
+      return false;
+    }
+    //need NTLM authentication for both 'GET' (wsdl retrieval) and 'POST' (Web Service invocation)
+    return true;
+  }
+
   request(rurl, data, callback, exheaders, exoptions) {
     var self = this;
     var options = self.buildRequest(rurl, data, exheaders, exoptions);
     var headers = options.headers;
     var req;
 
-    //typically clint.js would do addOptions() if security is set to get all security options added to options{}. But client.js
-    //addoptions() code runs after this code is trying to contact server to load remote WSDL, hence we would NTLM authentication
-    //object passed in as option to createClient( ) call for now. Revisit.
+    //typically clint.js would do addOptions() if security is set in order to get all security options added to options{}. But client.js
+    //addOptions() code runs after this code is trying to contact server to load remote WSDL, hence we have NTLM authentication
+    //object passed in as option to createClient() call for now. Revisit.
     var ntlmSecurity = this.options.NTLMSecurity;
-    if (ntlmSecurity == null) {
+    var ntlmAuth = self.isNtlmAuthRequired(ntlmSecurity, options.method);
+    if (!ntlmAuth) {
       req = self._request(options, function (err, res, body) {
-      if (err) {
-        return callback(err);
-      }
-      body = self.handleResponse(req, res, body);
-      callback(null, res, body);
-    });
-    } else {
-      //NTLMSecurity code needs 'url' in options{} and it should be plain string, not parsed uri
-      options.url = rurl;
-      options.username = ntlmSecurity.username;
-      options.password = ntlmSecurity.password;
-      options.domain = ntlmSecurity.domain;
-      options.workstation = ntlmSecurity.workstation;
-      //httpntlm code uses lower case for method names - 'get', 'post' etc
-      var method = options.method.toLocaleLowerCase();
-      req = httpntlm['method'](method, options, function (err, res) {
         if (err) {
           return callback(err);
         }
-        var body = self.handleResponse(req, res, body);
+        body = self.handleResponse(body);
         callback(null, res, body);
       });
-    }
+    } else {
+        //httpntlm code needs 'url' in options{}. It should be plain string, not parsed uri
+        options.url = rurl;
+        options.username = ntlmSecurity.username;
+        options.password = ntlmSecurity.password;
+        options.domain = ntlmSecurity.domain;
+        options.workstation = ntlmSecurity.workstation;
+        //httpntlm code uses lower case for method names - 'get', 'post' etc
+        var method = options.method.toLocaleLowerCase();
+        req = httpntlm['method'](method, options, function (err, res) {
+          if (err) {
+            return callback(err);
+          }
+          var body = self.handleResponse(res.body);
+          callback(null, res, body);
+        });
+      }
 
     return req;
   }

--- a/src/http.js
+++ b/src/http.js
@@ -126,13 +126,13 @@ class HttpClient {
     var ntlmSecurity = this.options.NTLMSecurity;
     var ntlmAuth = self.isNtlmAuthRequired(ntlmSecurity, options.method);
     if (!ntlmAuth) {
-      req = self._request(options, function (err, res, body) {
-        if (err) {
-          return callback(err);
-        }
-        body = self.handleResponse(body);
-        callback(null, res, body);
-      });
+        req = self._request(options, function (err, res, body) {
+          if (err) {
+            return callback(err);
+          }
+          body = self.handleResponse(body);
+          callback(null, res, body);
+        });
     } else {
         //httpntlm code needs 'url' in options{}. It should be plain string, not parsed uri
         options.url = rurl;

--- a/src/http.js
+++ b/src/http.js
@@ -87,7 +87,7 @@ class HttpClient {
    * @param {Object} body The http body
    * @param {Object} The parsed body
    */
-  handleResponse(body) {
+  handleResponse(req, res, body) {
     debug('Http response body: %j', body);
     if (typeof body === 'string') {
       // Remove any extra characters that appear before or after the SOAP
@@ -130,7 +130,7 @@ class HttpClient {
         if (err) {
           return callback(err);
         }
-        body = self.handleResponse(body);
+        body = self.handleResponse(req, res, body);
         callback(null, res, body);
       });
     } else {
@@ -146,7 +146,7 @@ class HttpClient {
           if (err) {
             return callback(err);
           }
-          var body = self.handleResponse(res.body);
+          var body = self.handleResponse(req, res, res.body);
           callback(null, res, body);
         });
       }

--- a/src/http.js
+++ b/src/http.js
@@ -110,7 +110,7 @@ class HttpClient {
       //In some WebServices, getting remote WSDL is not NTLM authenticated. Only WebService invocation is NTLM authenticated.
       return false;
     }
-    //need NTLM authentication for both 'GET' (wsdl retrieval) and 'POST' (Web Service invocation)
+    //need NTLM authentication for both 'GET' (remote wsdl retrieval) and 'POST' (Web Service invocation)
     return true;
   }
 
@@ -126,13 +126,13 @@ class HttpClient {
     var ntlmSecurity = this.options.NTLMSecurity;
     var ntlmAuth = self.isNtlmAuthRequired(ntlmSecurity, options.method);
     if (!ntlmAuth) {
-        req = self._request(options, function (err, res, body) {
-          if (err) {
-            return callback(err);
-          }
-          body = self.handleResponse(body);
-          callback(null, res, body);
-        });
+      req = self._request(options, function (err, res, body) {
+        if (err) {
+          return callback(err);
+        }
+        body = self.handleResponse(body);
+        callback(null, res, body);
+      });
     } else {
         //httpntlm code needs 'url' in options{}. It should be plain string, not parsed uri
         options.url = rurl;

--- a/src/security/NTLMSecurity.js
+++ b/src/security/NTLMSecurity.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var _ = require('lodash');
+var Security = require('./security');
+
+class NTLMSecurity extends Security {
+  constructor(username, password, domain, workstation, options) {
+    super(options);
+    this.username = username;
+    this.password = password;
+    this.domain = domain;
+    this.workstation = workstation;
+  }
+
+  addOptions(options) {
+    options.username = this.username;
+    options.password = this.password;
+    options.domain = this.domain;
+    options.workstation = this.workstation;
+    _.merge(options, this.options);
+  }
+}
+
+
+module.exports = NTLMSecurity;

--- a/src/security/NTLMSecurity.js
+++ b/src/security/NTLMSecurity.js
@@ -4,12 +4,14 @@ var _ = require('lodash');
 var Security = require('./security');
 
 class NTLMSecurity extends Security {
-  constructor(username, password, domain, workstation, options) {
+  constructor(username, password, domain, workstation, wsdlAuthRequired, options) {
     super(options);
     this.username = username;
     this.password = password;
     this.domain = domain;
     this.workstation = workstation;
+    //set this to true/false if remote WSDL retrieval needs NTLM authentication or not
+    this.wsdlAuthRequired = wsdlAuthRequired;
   }
 
   addOptions(options) {
@@ -17,6 +19,7 @@ class NTLMSecurity extends Security {
     options.password = this.password;
     options.domain = this.domain;
     options.workstation = this.workstation;
+    options.wsdlAuthRequired = this.wsdlAuthRequired;
     _.merge(options, this.options);
   }
 }

--- a/src/security/WSSecurityCert.js
+++ b/src/security/WSSecurityCert.js
@@ -6,7 +6,7 @@ var ursa = optional('ursa');
 var fs = require('fs');
 var path = require('path');
 var SignedXml = require('xml-crypto').SignedXml;
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var Security = require('./security');
 var xmlHandler = require('../parser/xmlHandler');
 

--- a/src/security/index.js
+++ b/src/security/index.js
@@ -13,5 +13,6 @@ module.exports = {
   ClientSSLSecurityPFX: require('./ClientSSLSecurityPFX'),
   WSSecurity: require('./WSSecurity'),
   BearerSecurity: require('./BearerSecurity'),
-  WSSecurityCert: WSSecurityCert
+  WSSecurityCert: WSSecurityCert,
+  NTLMSecurity: require('./NTLMSecurity')
 };

--- a/src/server.js
+++ b/src/server.js
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2011 Vinay Pulim <vinay@milewise.com>
- * MIT Licensed
- */
-
 'use strict';
 
 var g = require('./globalize');

--- a/src/soap.js
+++ b/src/soap.js
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2011 Vinay Pulim <vinay@milewise.com>
- * MIT Licensed
- */
-
 "use strict";
 
 var Client = require('./client'),


### PR DESCRIPTION
@raymondfeng  PTAL
Please note the way NTLM security object is set to the client - See NTLM.js example under /example directory. NTLM security object is passed in through client option by the caller instead of caller doing client.setSecurity() unlike other security support we have currently. The reason NTLM security object has to be set while creating client itself rather than after client object is created is because for NTLM auth is needed for loading/retrieval of remote wsdl which happens in http.request() method. Other security objects doesn't need to be set during http 'GET' unlike this one. Open to suggestions if we can make it same as other security setting pattern.