### PR TITLE
Proper support for xsi:type  

### DIFF
--- a/test/wsdl/strict/doc_literal_test.wsdl
+++ b/test/wsdl/strict/doc_literal_test.wsdl
@@ -10,8 +10,8 @@
     <wsdl:types>
         <xsd:schema targetNamespace="http://example.com/doc_literal_test.xsd"
                     xmlns:xsd="http://www.w3.org/2000/10/XMLSchema">
-            <xsd:element name="xElement" type="xsd:boolean"/>
-            <xsd:element name="yElement" type="xsd:boolean"/>
+            <xsd:element name="xElement" type="xsd:anytype"/>
+            <xsd:element name="yElement" type="xsd:float"/>
             <xsd:element name="zElement" type="xsd:boolean"/>
         </xsd:schema>
     </wsdl:types>

--- a/test/wsdl/strict/doc_literal_wrapped_test.wsdl
+++ b/test/wsdl/strict/doc_literal_wrapped_test.wsdl
@@ -20,6 +20,7 @@
                         <xsd:element name="x" type="xsd:int"/>
                         <xsd:element name="y" type="xsd:float"/>
                      </xsd:sequence>
+                     <xsd:attribute name="id" type="xsd:string" use="optional"/>
                 </xsd:complexType>
             </xsd:element>
 


### PR DESCRIPTION
Current code doesn't read xsi $attribute and $value from JSON input if the element is defined as xsd:anyType. xsd:anyType results without a type in current code which defaults to isSimple=false. 2nd problem is, if the element value is of simple or date type, current code does not add xsi:type to it. Fixed these problems and added 2 test cases to cover these.
@raymondfeng PTAL