### PR TITLE
support forcing soap version

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -58,6 +58,7 @@ class Base extends EventEmitter {
     options = options || {};
     this.wsdl.options.attributesKey = options.attributesKey || 'attributes';
     this.wsdl.options.envelopeKey = options.envelopeKey || 'soap';
+    this.wsdl.options.forceSoapVersion = options.forceSoapVersion;
   }
 
   static createSOAPEnvelope(prefix, nsURI) {

--- a/src/client.js
+++ b/src/client.js
@@ -158,7 +158,7 @@ class Client extends Base {
     //Unlike other security objects, NTLMSecurity is passed in through client options rather than client.setSecurity(ntlmSecurity) as some
     //remote wsdl retrieval needs NTLM authentication before client object gets created. Hence, set NTLMSecurity instance to the client object
     //so that it will be similar to other security objects from this point onwards.
-    if (self.httpClient.options.NTLMSecurity != null) {
+    if (self.httpClient.options && self.httpClient.options.NTLMSecurity) {
       self.security = self.httpClient.options.NTLMSecurity;
     }
 

--- a/src/client.js
+++ b/src/client.js
@@ -119,8 +119,9 @@ class Client extends Base {
     var soapNsURI = 'http://schemas.xmlsoap.org/soap/envelope/';
     var soapNsPrefix = this.wsdl.options.envelopeKey || 'soap';
 
+    var soapVersion = this.wsdl.options.forceSoapVersion || operation.soapVersion;
 
-    if (operation.soapVersion === '1.2') {
+    if (soapVersion === '1.2') {
       headers['Content-Type'] = 'application/soap+xml; charset=utf-8';
       soapNsURI = 'http://www.w3.org/2003/05/soap-envelope';
     }
@@ -135,7 +136,7 @@ class Client extends Base {
       soapAction = ((ns.lastIndexOf("/") !== ns.length - 1) ? ns + "/" : ns) + name;
     }
 
-    if (operation.soapVersion !== '1.2') {
+    if (soapVersion !== '1.2') {
       headers.SOAPAction = '"' + soapAction + '"';
     }
 
@@ -153,6 +154,13 @@ class Client extends Base {
     }
 
     debug('client request. headers: %j', headers);
+
+    //Unlike other security objects, NTLMSecurity is passed in through client options rather than client.setSecurity(ntlmSecurity) as some
+    //remote wsdl retrieval needs NTLM authentication before client object gets created. Hence, set NTLMSecurity instance to the client object
+    //so that it will be similar to other security objects from this point onwards.
+    if (self.httpClient.options.NTLMSecurity != null) {
+      self.security = self.httpClient.options.NTLMSecurity;
+    }
 
     // Allow the security object to add headers
     if (self.security && self.security.addHttpHeaders) {

--- a/src/parser/element.js
+++ b/src/parser/element.js
@@ -62,6 +62,7 @@ class Element {
       this.valueKey = options.valueKey || '$value';
       this.xmlKey = options.xmlKey || '$xml';
       this.ignoredNamespaces = options.ignoredNamespaces || [];
+      this.forceSoapVersion = options.forceSoapVersion;
     } else {
       this.valueKey = '$value';
       this.xmlKey = '$xml';

--- a/src/parser/wsdl.js
+++ b/src/parser/wsdl.js
@@ -121,6 +121,8 @@ class WSDL {
       this.options.ignoredNamespaces = this.ignoredNamespaces;
     }
 
+    this.options.forceSoapVersion = options.forceSoapVersion;
+
     this.options.valueKey = options.valueKey || this.valueKey;
     this.options.xmlKey = options.xmlKey || this.xmlKey;
 

--- a/test/server-client-document-test.js
+++ b/test/server-client-document-test.js
@@ -788,39 +788,39 @@ describe('Document style tests', function() {
 
      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
      <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-        <soap:Header/>
-        <soap:Body>
-          <ns1:myMethod xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.xsd">
-            <x>200</x>
-            <y>10.55</y>
-          </ns1:myMethod>
-        </soap:Body>
+     <soap:Header/>
+     <soap:Body>
+     <ns1:myMethod xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.xsd">
+     <x>200</x>
+     <y>10.55</y>
+     </ns1:myMethod>
+     </soap:Body>
      </soap:Envelope>
 
      Server Response. Passing client option=forceSoapVersion=1.1 has no effect on server side response. The server will
      create a 1.1 or 1.2 response based on whether WSDL is 1.1 or 1.2
      //
      <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
-        <soap:Header/>
-        <soap:Body>
-          <soap:Fault>
-            <soap:Code>
-              <soap:Value>soap:Sender</soap:Value>
-              <soap:Subcode>
-              <soap:Value>rpc:BadArguments</soap:Value>
-              </soap:Subcode>
-            </soap:Code>
-            <soap:Reason>
-                <soap:Text>Processing Error</soap:Text>
-            </soap:Reason>
-            <soap:Detail>
-              <ns1:myMethodFault2 xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.wsdl">
-                <errorMessage2>MyMethod Business Exception message</errorMessage2>
-                <value2>10</value2>
-              </ns1:myMethodFault2>
-            </soap:Detail>
-          </soap:Fault>
+     <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+     <soap:Header/>
+     <soap:Body>
+     <soap:Fault>
+     <soap:Code>
+     <soap:Value>soap:Sender</soap:Value>
+     <soap:Subcode>
+     <soap:Value>rpc:BadArguments</soap:Value>
+     </soap:Subcode>
+     </soap:Code>
+     <soap:Reason>
+     <soap:Text>Processing Error</soap:Text>
+     </soap:Reason>
+     <soap:Detail>
+     <ns1:myMethodFault2 xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.wsdl">
+     <errorMessage2>MyMethod Business Exception message</errorMessage2>
+     <value2>10</value2>
+     </ns1:myMethodFault2>
+     </soap:Detail>
+     </soap:Fault>
      </soap:Body>
      </soap:Envelope>
 
@@ -835,12 +835,12 @@ describe('Document style tests', function() {
           assert.ok(err);
 
           //check if the client request has soap 1.1 namespace "http://schemas.xmlsoap.org/soap/envelope/"
-          var request = client.lastMessage;
-          var index = body.indexOf('<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">');
+          var request = client.lastRequest;
+          var index = request.indexOf('<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">');
           assert.ok(index > -1);
 
           //check  server response - should still contain soap 1.2 namespace "http://www.w3.org/2003/05/soap-envelope"
-          var index = body.indexOf(' <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">');
+          var index = body.indexOf('<soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">');
           assert.ok(index > -1);
           done();
         });
@@ -848,6 +848,8 @@ describe('Document style tests', function() {
     });
 
   });
+
+
 });
 
 

--- a/test/server-client-document-test.js
+++ b/test/server-client-document-test.js
@@ -715,7 +715,139 @@ describe('Document style tests', function() {
 
   });
 
+  describe('forceSoapVersion=1.1 in client options', function () {
 
+    var test = {};
+    test.server = null;
+    test.service = {
+      DocLiteralWrappedService: {
+        DocLiteralWrappedPort: {
+          myMethod: function (args, cb, soapHeader) {
+            throw {
+              Fault: {
+                Code: {
+                  Value: "soap:Sender",
+                  Subcode: { Value: "rpc:BadArguments" }
+                },
+                Reason: { Text: "Processing Error" },
+                Detail:
+                {myMethodFault2:
+                {errorMessage2: 'MyMethod Business Exception message', value2: 10}
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    before(function (done) {
+      fs.readFile(__dirname + '/wsdl/strict/doc_literal_wrapped_test_soap12.wsdl', 'utf8', function (err, data) {
+        assert.ok(!err);
+        test.wsdl = data;
+        done();
+      });
+    });
+
+    beforeEach(function (done) {
+      test.server = http.createServer(function (req, res) {
+        res.statusCode = 404;
+        res.end();
+      });
+
+      test.server.listen(15099, null, null, function () {
+        test.soapServer = soap.listen(test.server, '/doc_literal_wrapped_test_soap12', test.service, test.wsdl);
+        test.baseUrl =
+          'http://' + test.server.address().address + ":" + test.server.address().port;
+
+        //windows return 0.0.0.0 as address and that is not
+        //valid to use in a request
+        if (test.server.address().address === '0.0.0.0' || test.server.address().address === '::') {
+          test.baseUrl =
+            'http://127.0.0.1:' + test.server.address().port;
+        }
+
+        done();
+      });
+    });
+
+    afterEach(function (done) {
+      test.server.close(function () {
+        test.server = null;
+        delete test.soapServer;
+        test.soapServer = null;
+        done();
+      });
+    });
+
+    //Even though WSDL is 1.2, this test case is passing client option as forceSoapVersion=1.1, the request created by
+    //client will be soap a 1.1 request
+    /*
+
+     Client Request
+
+     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+     <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+        <soap:Header/>
+        <soap:Body>
+          <ns1:myMethod xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.xsd">
+            <x>200</x>
+            <y>10.55</y>
+          </ns1:myMethod>
+        </soap:Body>
+     </soap:Envelope>
+
+     Server Response. Passing client option=forceSoapVersion=1.1 has no effect on server side response. The server will
+     create a 1.1 or 1.2 response based on whether WSDL is 1.1 or 1.2
+     //
+     <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+      <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">
+        <soap:Header/>
+        <soap:Body>
+          <soap:Fault>
+            <soap:Code>
+              <soap:Value>soap:Sender</soap:Value>
+              <soap:Subcode>
+              <soap:Value>rpc:BadArguments</soap:Value>
+              </soap:Subcode>
+            </soap:Code>
+            <soap:Reason>
+                <soap:Text>Processing Error</soap:Text>
+            </soap:Reason>
+            <soap:Detail>
+              <ns1:myMethodFault2 xmlns:ns1="http://example.com/doc_literal_wrapped_test_soap12.wsdl">
+                <errorMessage2>MyMethod Business Exception message</errorMessage2>
+                <value2>10</value2>
+              </ns1:myMethodFault2>
+            </soap:Detail>
+          </soap:Fault>
+     </soap:Body>
+     </soap:Envelope>
+
+     */
+
+
+    it('Force 1.1 version onto SOAP 1.2 WSDL request', function (done) {
+      soap.createClient(test.baseUrl + '/doc_literal_wrapped_test_soap12?wsdl', {forceSoapVersion: '1.1'}, function (err, client) {
+        assert.ok(!err);
+        client.myMethod({x: 200, y: 10.55}, function (err, result, body) {
+          //this is fault response. hence err will be received
+          assert.ok(err);
+
+          //check if the client request has soap 1.1 namespace "http://schemas.xmlsoap.org/soap/envelope/"
+          var request = client.lastMessage;
+          var index = body.indexOf('<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">');
+          assert.ok(index > -1);
+
+          //check  server response - should still contain soap 1.2 namespace "http://www.w3.org/2003/05/soap-envelope"
+          var index = body.indexOf(' <soap:Envelope xmlns:soap="http://www.w3.org/2003/05/soap-envelope">');
+          assert.ok(index > -1);
+          done();
+        });
+      });
+    });
+
+  });
 });
 
 


### PR DESCRIPTION
Supports forceSoapVersion=1.1 or 1.2 which can be passed in as client option to createClient() method. By default the client request is created based on whether wsdl is defined as 1.1 or 1.2. forceSoapVersion=1.1 will let the user to override this. Also added a test case. 
@raymondfeng PTAL