### PR TITLE
add prettyPrint to client options

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -224,8 +224,16 @@ class Client extends Base {
       self.security.postProcess(envelope.header, envelope.body);
     }
 
-    message = envelope.body.toString({pretty: true});
-    xml = envelope.doc.end({pretty: true});
+    //Bydefault pretty print is true and request envelope is created with newlines and indentations
+    var prettyPrint = true;
+
+    //some web services don't accept request envelope with newlines and indentations in which case user has to set {prettyPrint: false} as client option
+    if (self.httpClient.options.prettyPrint != null) {
+      prettyPrint = self.httpClient.options.prettyPrint;
+    }
+
+    message = envelope.body.toString({pretty: prettyPrint});
+    xml = envelope.doc.end({pretty: prettyPrint});
 
     debug('Request envelope: %s', xml);
 

--- a/src/client.js
+++ b/src/client.js
@@ -226,9 +226,8 @@ class Client extends Base {
 
     //Bydefault pretty print is true and request envelope is created with newlines and indentations
     var prettyPrint = true;
-
     //some web services don't accept request envelope with newlines and indentations in which case user has to set {prettyPrint: false} as client option
-    if (self.httpClient.options.prettyPrint != null) {
+    if (self.httpClient.options && self.httpClient.options.prettyPrint !== undefined) {
       prettyPrint = self.httpClient.options.prettyPrint;
     }
 

--- a/src/http.js
+++ b/src/http.js
@@ -2,8 +2,10 @@
 
 var url = require('url');
 var req = require('request');
-var debug = require('debug')('st-soap:http');
+var debug = require('debug')('strong-soap:http');
+var debugSensitive = require('debug')('strong-soap:http:sensitive');
 var httpntlm = require('httpntlm');
+
 
 var VERSION = require('../package.json').version;
 
@@ -142,6 +144,8 @@ class HttpClient {
         options.workstation = ntlmSecurity.workstation;
         //httpntlm code uses lower case for method names - 'get', 'post' etc
         var method = options.method.toLocaleLowerCase();
+        debugSensitive('NTLM options: %j for method: %s', options, method);
+        debug('httpntlm method: %s', method);
         req = httpntlm['method'](method, options, function (err, res) {
           if (err) {
             return callback(err);


### PR DESCRIPTION
By default pretty print is 'true' which means the code creates request envelope with new lines and proper indentations etc. However some web services don't accept request env with new lines and indentations. Hence added prettyPrint as client configuration option to make it configurable where user can pass client option as {prettyPrint: false}. 
@raymondfeng PTAL