### PR TITLE
Fix multiRef merging

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -607,7 +607,7 @@ class XMLHandler {
     var merge = function(href, obj) {
       for (var j in obj) {
         if (obj.hasOwnProperty(j)) {
-          href.obj[j] = obj[j];
+          href.object[j] = obj[j];
         }
       }
     };


### PR DESCRIPTION
This fixes multiref merging, which was previously throwing `TypeError: Cannot set property '$attributes' of undefined`.