### PR TITLE
Initialize NTLMSecurity client option to wsdl option

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "_pretest": "jshint index.js lib test",
     "cover": "istanbul cover _mocha -- --timeout 10000 test/*-test.js test/security/*.js",
     "coveralls": "cat ./coverage/lcov.info | coveralls -v",
-    "test": "mocha --timeout 10000 test/*-test.js test/security/*.js",
+    "test": "mocha --timeout 60000 test/*-test.js test/security/*.js",
     "pretest": "babel src -d lib",
     "prepublish": "babel src -d lib"
   },

--- a/src/parser/wsdl.js
+++ b/src/parser/wsdl.js
@@ -140,6 +140,10 @@ class WSDL {
       this.options.ignoreBaseNameSpaces = ignoreBaseNameSpaces;
     else
       this.options.ignoreBaseNameSpaces = this.ignoreBaseNameSpaces;
+
+    if (options.NTLMSecurity) {
+      this.options.NTLMSecurity = options.NTLMSecurity;
+    }
   }
 
   _processNextInclude(includes, callback) {


### PR DESCRIPTION
When wsdl imports another wsdl, the code which loads the imported wsdl goes through a different execution path where the NTLMSecurity client option is not available in wsdl options. This PR fixes this issue where wsdl._initializeOptions(..) method initializes NTLMSecurity from client options similar to other client options. @raymondfeng or @deepakrkris PTAL