### PR TITLE
Change capitalization of readme file

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,4 +1,4 @@
-# Soap 
+# Strong-soap 
 
 > A SOAP client and server for node.js.
 


### PR DESCRIPTION
This PR just changes `Readme.md` to `README.md`.  This is how all the other repos spell the file, and (more importantly) the documentation uses [a script](https://github.com/strongloop/loopback.io/blob/gh-pages/update-readmes.sh) that assumes the README filename is spelled this way to grab it and include it into the docs.

I also changed the title to `Strong-soap` according to the [README guidelines](http://loopback.io/doc/en/contrib/README-guidelines.html#organization).

@rashmihunt 