### PR TITLE
allow xsd:include to include a schema without target namespace

### DIFF
--- a/src/parser/wsdl.js
+++ b/src/parser/wsdl.js
@@ -176,8 +176,16 @@ class WSDL {
       self._includesWsdl.push(wsdl);
 
       if (wsdl.definitions instanceof Definitions) {
+        // Set namespace for included schema that does not have targetNamespace
+        if (undefined in wsdl.definitions.schemas) {
+          if (include.namespace != null) {
+            // If A includes B and B includes C, B & C can both have no targetNamespace
+            wsdl.definitions.schemas[include.namespace] = wsdl.definitions.schemas[undefined];
+            delete wsdl.definitions.schemas[undefined];
+          }
+        }
         _.mergeWith(self.definitions, wsdl.definitions, function(a, b) {
-          return (a instanceof Schema) ? a.merge(b) : undefined;
+          return (a instanceof Schema) ? a.merge(b, include.type === 'include') : undefined;
         });
       } else {
         self.definitions.schemas[include.namespace ||

--- a/src/parser/xsd/schema.js
+++ b/src/parser/xsd/schema.js
@@ -18,9 +18,11 @@ class Schema extends XSDElement {
     this.attributeGroups = {};
   }
 
-  merge(source) {
+  merge(source, isInclude) {
     assert(source instanceof Schema);
-    if (this.$targetNamespace === source.$targetNamespace) {
+    if (this.$targetNamespace === source.$targetNamespace ||
+      // xsd:include allows the target schema that does not have targetNamspace
+      (isInclude && source.$targetNamespace === undefined)) {
       _.merge(this.complexTypes, source.complexTypes);
       _.merge(this.simpleTypes, source.simpleTypes);
       _.merge(this.elements, source.elements);
@@ -45,7 +47,8 @@ class Schema extends XSDElement {
           this.includes.push({
             namespace: child.$namespace || child.$targetNamespace
             || this.$targetNamespace,
-            location: location
+            location: location,
+            type: child.name // include or import
           });
         }
         break;

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -171,6 +171,15 @@ describe('wsdl-tests', function() {
       });
     });
 
+    it('handles xsd includes', function(done) {
+      soap.createClient(__dirname + '/wsdl/xsdinclude/xsd_include.wsdl', function(err, client) {
+        assert.ok(!err);
+        var schema = client.wsdl.definitions.schemas['http://www.dummy.com/Types'];
+        var simpleTypes = Object.keys(schema.simpleTypes);
+        simpleTypes.should.eql(['IdType', 'NameType', 'AnotherIdType'])
+        done();
+      });
+    });
   });
 });
 

--- a/test/wsdl/xsdinclude/types-without-tns.xsd
+++ b/test/wsdl/xsdinclude/types-without-tns.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://www.dummy.com/Types"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+    <xs:simpleType name="AnotherIdType">
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d{5,15}"/>
+        </xs:restriction>
+    </xs:simpleType>
+</xs:schema>

--- a/test/wsdl/xsdinclude/xsd_include.wsdl
+++ b/test/wsdl/xsdinclude/xsd_include.wsdl
@@ -12,6 +12,7 @@
                    elementFormDefault="qualified"
                    attributeFormDefault="unqualified">
             <xs:include schemaLocation="types.xsd"/>
+            <xs:include schemaLocation="types-without-tns.xsd"/>
             <xs:element name="DummyRequest">
                 <xs:complexType>
                     <xs:sequence>


### PR DESCRIPTION
### Description

Fix #137

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #137 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
