### PR TITLE
fix: make sure xml elements are mapped based the order of xsd

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -227,6 +227,25 @@ class XMLHandler {
     return xsiTypeDescriptor;
   }
 
+  _sortKeys(val, elementOrder) {
+    function compare(n1, n2, order) {
+      let i1 = order.indexOf(n1);
+      if (i1 === -1) i1 = order.length;
+      let i2 = order.indexOf(n2);
+      if (i2 === -1) i2 = order.length;
+      return i1 - i2;
+    }
+    const keys = Object.keys(val);
+    var names = [].concat(keys).sort((n1, n2) => {
+      let result = compare(n1, n2, elementOrder);
+      if (result ===0) {
+        result = compare(n1, n2, keys);
+      }
+      return result;
+    });
+    return names;
+  }
+
   /**
    * Map a JSON object into an XML type
    * @param {XMLElement} node The root node
@@ -247,11 +266,13 @@ class XMLHandler {
     descriptor = xsiType || descriptor;
 
     var elements = {}, attributes = {};
+    var elementOrder = [];
     if (descriptor != null) {
       for (let i = 0, n = descriptor.elements.length; i < n; i++) {
         let elementDescriptor = descriptor.elements[i];
         let elementName = elementDescriptor.qname.name;
         elements[elementName] = elementDescriptor;
+        elementOrder.push(elementName);
       }
     }
 
@@ -265,7 +286,8 @@ class XMLHandler {
 
     // handle later if value is an array 
     if (!Array.isArray(val)) {
-      for (let p in val) {
+      const names = this._sortKeys(val, elementOrder);
+      for (let p of names) {
         if (p === this.options.attributesKey)
           continue;
 	      let child = val[p];

--- a/test/request-response-samples/UpdateProfile__correct_namespaces_for_elements_with_base/request.xml
+++ b/test/request-response-samples/UpdateProfile__correct_namespaces_for_elements_with_base/request.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-<soap:Header/>
-<soap:Body>
-		<ns1:UpdateProfileRequest xmlns:ns1="http://www.bigdatacollect.or/Name/Types">
-			<ns1:Profile>
-				<ns1:IDs>
-					<ns2:UniqueID xmlns:ns2="http://www.bigdatacollect.or/Common/Types" source="TESTSOURCE">100</ns2:UniqueID>
-				</ns1:IDs>
-				<ns1:Addresses>
-					<ns1:NameAddress>
-						<ns2:AddressLine xmlns:ns2="http://www.bigdatacollect.or/Common/Types">Another Address</ns2:AddressLine>
-					</ns1:NameAddress>
-					<ns1:NameAddress>
-						<ns2:AddressLine xmlns:ns2="http://www.bigdatacollect.or/Common/Types">My Address</ns2:AddressLine>
-					</ns1:NameAddress>
-				</ns1:Addresses>
-				<ns1:Phones>
-					<ns1:NamePhone primary="true">
-						<ns2:PhoneData xmlns:ns2="http://www.bigdatacollect.or/Common/Types">
-							<ns2:PhoneNumber>123</ns2:PhoneNumber>
-						</ns2:PhoneData>
-					</ns1:NamePhone>
-					<ns1:NamePhone primary="false">
-						<ns2:PhoneData xmlns:ns2="http://www.bigdatacollect.or/Common/Types">
-							<ns2:PhoneNumber>456</ns2:PhoneNumber>
-						</ns2:PhoneData>
-					</ns1:NamePhone>
-				</ns1:Phones>
-			</ns1:Profile>
-		</ns1:UpdateProfileRequest>
-</soap:Body>
+  <soap:Header/>
+  <soap:Body>
+    <ns1:UpdateProfileRequest xmlns:ns1="http://www.bigdatacollect.or/Name/Types">
+      <ns1:Profile>
+        <ns1:IDs>
+          <ns2:UniqueID xmlns:ns2="http://www.bigdatacollect.or/Common/Types" source="TESTSOURCE">100</ns2:UniqueID>
+        </ns1:IDs>
+        <ns1:Phones>
+          <ns1:NamePhone primary="true">
+            <ns2:PhoneData xmlns:ns2="http://www.bigdatacollect.or/Common/Types">
+              <ns2:PhoneNumber>123</ns2:PhoneNumber>
+            </ns2:PhoneData>
+          </ns1:NamePhone>
+          <ns1:NamePhone primary="false">
+            <ns2:PhoneData xmlns:ns2="http://www.bigdatacollect.or/Common/Types">
+              <ns2:PhoneNumber>456</ns2:PhoneNumber>
+            </ns2:PhoneData>
+          </ns1:NamePhone>
+        </ns1:Phones>
+        <ns1:Addresses>
+          <ns1:NameAddress>
+            <ns2:AddressLine xmlns:ns2="http://www.bigdatacollect.or/Common/Types">Another Address</ns2:AddressLine>
+          </ns1:NameAddress>
+          <ns1:NameAddress>
+            <ns2:AddressLine xmlns:ns2="http://www.bigdatacollect.or/Common/Types">My Address</ns2:AddressLine>
+          </ns1:NameAddress>
+        </ns1:Addresses>
+      </ns1:Profile>
+    </ns1:UpdateProfileRequest>
+  </soap:Body>
 </soap:Envelope>

--- a/test/request-response-samples/UpdateProfile__correct_namespaces_for_elements_with_base_ignorednamespaces/request.xml
+++ b/test/request-response-samples/UpdateProfile__correct_namespaces_for_elements_with_base_ignorednamespaces/request.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-<soap:Header/>
-<soap:Body>
-		<ns1:UpdateProfileRequest xmlns:ns1="http://www.bigdatacollect.or/Name/Types">
-			<Profile>
-				<IDs>
-					<UniqueID source="TESTSOURCE">100</UniqueID>
-				</IDs>
-				<Addresses>
-					<NameAddress>
-						<AddressLine>Another Address</AddressLine>
-					</NameAddress>
-					<NameAddress>
-						<AddressLine>My Address</AddressLine>
-					</NameAddress>
-				</Addresses>
-				<Phones>
-					<NamePhone primary="true">
-						<PhoneData>
-							<PhoneNumber>123</PhoneNumber>
-						</PhoneData>
-					</NamePhone>
-					<NamePhone primary="false">
-						<PhoneData>
-							<PhoneNumber>456</PhoneNumber>
-						</PhoneData>
-					</NamePhone>
-				</Phones>
-			</Profile>
-		</ns1:UpdateProfileRequest>
-</soap:Body>
+  <soap:Header/>
+  <soap:Body>
+    <ns1:UpdateProfileRequest xmlns:ns1="http://www.bigdatacollect.or/Name/Types">
+      <Profile>
+        <IDs>
+          <UniqueID source="TESTSOURCE">100</UniqueID>
+        </IDs>
+        <Phones>
+          <NamePhone primary="true">
+            <PhoneData>
+              <PhoneNumber>123</PhoneNumber>
+            </PhoneData>
+          </NamePhone>
+          <NamePhone primary="false">
+            <PhoneData>
+              <PhoneNumber>456</PhoneNumber>
+            </PhoneData>
+          </NamePhone>
+        </Phones>
+        <Addresses>
+          <NameAddress>
+            <AddressLine>Another Address</AddressLine>
+          </NameAddress>
+          <NameAddress>
+            <AddressLine>My Address</AddressLine>
+          </NameAddress>
+        </Addresses>
+      </Profile>
+    </ns1:UpdateProfileRequest>
+  </soap:Body>
 </soap:Envelope>

--- a/test/request-response-samples/UpdateProfile__correct_ns_context/request.xml
+++ b/test/request-response-samples/UpdateProfile__correct_ns_context/request.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-<soap:Header/>
-<soap:Body>
-		<ns1:UpdateProfileRequest xmlns:ns1="http://www.bigdatacollect.or/Name/Types">
-			<ns1:Profile>
-				<ns1:IDs>
-					<ns2:UniqueID xmlns:ns2="http://www.bigdatacollect.or/Common/Types" source="TESTSOURCE">100</ns2:UniqueID>
-					<ns2:UniqueID xmlns:ns2="http://www.bigdatacollect.or/Common/Types" source="TESTSOURCE2">100</ns2:UniqueID>
-					<ns2:UniqueID xmlns:ns2="http://www.bigdatacollect.or/Common/Types" source="TESTSOURCE3">100</ns2:UniqueID>
-				</ns1:IDs>
-				<ns1:Addresses>
-					<ns1:NameAddress>
-						<ns2:AddressLine xmlns:ns2="http://www.bigdatacollect.or/Common/Types">Another Address</ns2:AddressLine>
-					</ns1:NameAddress>
-					<ns1:NameAddress>
-						<ns2:AddressLine xmlns:ns2="http://www.bigdatacollect.or/Common/Types">My Address</ns2:AddressLine>
-					</ns1:NameAddress>
-				</ns1:Addresses>
-				<ns1:Phones>
-					<ns1:NamePhone primary="true">
-						<ns2:PhoneData xmlns:ns2="http://www.bigdatacollect.or/Common/Types">
-							<ns2:PhoneNumber>400123</ns2:PhoneNumber>
-						</ns2:PhoneData>
-						<ns1:details>
-						 <ns2:data xmlns:ns2="http://www.bigdatacollect.or/Common/Types" type="Extension">1001</ns2:data>
-						 <ns2:data xmlns:ns2="http://www.bigdatacollect.or/Common/Types" type="AreaCode">377</ns2:data>
-						</ns1:details>
-					</ns1:NamePhone>
-					<ns1:NamePhone primary="false">
-						<ns2:PhoneData xmlns:ns2="http://www.bigdatacollect.or/Common/Types">
-							<ns2:PhoneNumber>555010456</ns2:PhoneNumber>
-						</ns2:PhoneData>
-					</ns1:NamePhone>
-				</ns1:Phones>
-			</ns1:Profile>
-		</ns1:UpdateProfileRequest>
-</soap:Body>
+  <soap:Header/>
+  <soap:Body>
+    <ns1:UpdateProfileRequest xmlns:ns1="http://www.bigdatacollect.or/Name/Types">
+      <ns1:Profile>
+        <ns1:IDs>
+          <ns2:UniqueID xmlns:ns2="http://www.bigdatacollect.or/Common/Types" source="TESTSOURCE">100</ns2:UniqueID>
+          <ns2:UniqueID xmlns:ns2="http://www.bigdatacollect.or/Common/Types" source="TESTSOURCE2">100</ns2:UniqueID>
+          <ns2:UniqueID xmlns:ns2="http://www.bigdatacollect.or/Common/Types" source="TESTSOURCE3">100</ns2:UniqueID>
+        </ns1:IDs>
+        <ns1:Phones>
+          <ns1:NamePhone primary="true">
+            <ns2:PhoneData xmlns:ns2="http://www.bigdatacollect.or/Common/Types">
+              <ns2:PhoneNumber>400123</ns2:PhoneNumber>
+            </ns2:PhoneData>
+            <ns1:details>
+              <ns2:data xmlns:ns2="http://www.bigdatacollect.or/Common/Types" type="Extension">1001</ns2:data>
+              <ns2:data xmlns:ns2="http://www.bigdatacollect.or/Common/Types" type="AreaCode">377</ns2:data>
+            </ns1:details>
+          </ns1:NamePhone>
+          <ns1:NamePhone primary="false">
+            <ns2:PhoneData xmlns:ns2="http://www.bigdatacollect.or/Common/Types">
+              <ns2:PhoneNumber>555010456</ns2:PhoneNumber>
+            </ns2:PhoneData>
+          </ns1:NamePhone>
+        </ns1:Phones>
+        <ns1:Addresses>
+          <ns1:NameAddress>
+            <ns2:AddressLine xmlns:ns2="http://www.bigdatacollect.or/Common/Types">Another Address</ns2:AddressLine>
+          </ns1:NameAddress>
+          <ns1:NameAddress>
+            <ns2:AddressLine xmlns:ns2="http://www.bigdatacollect.or/Common/Types">My Address</ns2:AddressLine>
+          </ns1:NameAddress>
+        </ns1:Addresses>
+      </ns1:Profile>
+    </ns1:UpdateProfileRequest>
+  </soap:Body>
 </soap:Envelope>

--- a/test/request-response-samples/update__complex_extension_with_array_attributes/request.xml
+++ b/test/request-response-samples/update__complex_extension_with_array_attributes/request.xml
@@ -1,31 +1,46 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
-<soap:Header/>
-<soap:Body>
-		<ns1:update xmlns:ns1="urn:messages_2011_1.platform.webservices.netsuite.com">
-			<ns1:record internalId="42" externalId="Alex Dniprovskyy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com" xsi:type="ns2:Contact">
-				<ns2:firstName xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com">Allister</ns2:firstName>
-				<ns2:lastName xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com">Sullivan</ns2:lastName>
-				<ns2:nullFieldList xmlns:ns2="urn:core_2011_1.platform.webservices.netsuite.com">
-					<ns2:name>officephone</ns2:name>
-					<ns2:name>mobilephone</ns2:name>
-				</ns2:nullFieldList>
-				<ns2:phone xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com">800-555-2819</ns2:phone>
-				<ns2:subscriptionsList xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com" replaceAll="false">
-					<ns2:subscriptions tempId="34">
-						<ns2:subscribed>true</ns2:subscribed>
-						<ns2:subscription internalId="2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns3="urn:core_2011_1.platform.webservices.netsuite.com" xsi:type="ns3:RecordRef">
-							<ns3:name xmlns:ns3="urn:core_2011_1.platform.webservices.netsuite.com">Billing Communication</ns3:name>
-						</ns2:subscription>
-					</ns2:subscriptions>
-					<ns2:subscriptions>
-						<ns2:subscribed>true</ns2:subscribed>
-						<ns2:subscription internalId="1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:ns3="urn:core_2011_1.platform.webservices.netsuite.com" xsi:type="ns3:RecordRef">
-							<ns3:name xmlns:ns3="urn:core_2011_1.platform.webservices.netsuite.com">Marketing</ns3:name>
-						</ns2:subscription>
-					</ns2:subscriptions>
-				</ns2:subscriptionsList>
-			</ns1:record>
-		</ns1:update>
-</soap:Body>
+<soap:Envelope
+    xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+    <soap:Header/>
+    <soap:Body>
+        <ns1:update
+            xmlns:ns1="urn:messages_2011_1.platform.webservices.netsuite.com">
+            <ns1:record internalId="42" externalId="Alex Dniprovskyy"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com" xsi:type="ns2:Contact">
+                <ns2:nullFieldList
+                    xmlns:ns2="urn:core_2011_1.platform.webservices.netsuite.com">
+                    <ns2:name>officephone</ns2:name>
+                    <ns2:name>mobilephone</ns2:name>
+                </ns2:nullFieldList>
+                <ns2:firstName
+                    xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com">Allister</ns2:firstName>
+                <ns2:lastName
+                    xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com">Sullivan</ns2:lastName>
+                <ns2:phone
+                    xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com">800-555-2819</ns2:phone>
+                <ns2:subscriptionsList
+                    xmlns:ns2="urn:relationships_2011_1.lists.webservices.netsuite.com" replaceAll="false">
+                    <ns2:subscriptions tempId="34">
+                        <ns2:subscribed>true</ns2:subscribed>
+                        <ns2:subscription internalId="2"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns:ns3="urn:core_2011_1.platform.webservices.netsuite.com" xsi:type="ns3:RecordRef">
+                            <ns3:name
+                                xmlns:ns3="urn:core_2011_1.platform.webservices.netsuite.com">Billing Communication</ns3:name>
+                        </ns2:subscription>
+                    </ns2:subscriptions>
+                    <ns2:subscriptions>
+                        <ns2:subscribed>true</ns2:subscribed>
+                        <ns2:subscription internalId="1"
+                            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                            xmlns:ns3="urn:core_2011_1.platform.webservices.netsuite.com" xsi:type="ns3:RecordRef">
+                            <ns3:name
+                                xmlns:ns3="urn:core_2011_1.platform.webservices.netsuite.com">Marketing</ns3:name>
+                        </ns2:subscription>
+                    </ns2:subscriptions>
+                </ns2:subscriptionsList>
+            </ns1:record>
+        </ns1:update>
+    </soap:Body>
 </soap:Envelope>

--- a/test/wsdl/typeref/request.xml.js
+++ b/test/wsdl/typeref/request.xml.js
@@ -6,12 +6,12 @@ module.exports =
       '<ns3:rqUID xmlns:ns3=\"http://example.org/ns2\">001</ns3:rqUID>\n      '+
     '</ns2:ecomRq>\n      '+
     '<ns2:item>\n        '+
-      '<qty>100</qty>\n        '+
-      '<ns3:itemId xmlns:ns3=\"http://example.org/ns2\">item01</ns3:itemId>\n      '+
+      '<ns3:itemId xmlns:ns3=\"http://example.org/ns2\">item01</ns3:itemId>\n        '+
+      '<qty>100</qty>\n      '+
     '</ns2:item>\n      '+
       '<ns3:backupItem xmlns:ns3=\"http://example.org/ns2\">\n        '+
-      '<qty>50</qty>\n        '+
-      '<ns3:itemId>item02</ns3:itemId>\n      '+
+      '<ns3:itemId>item02</ns3:itemId>\n        '+
+      '<qty>50</qty>\n      '+
       '</ns3:backupItem>\n    '+
     '</ns2:itemRq>\n  '+
     '</ns2:orderRq>\n'+


### PR DESCRIPTION
JSON objects might provide properties in different order than the XML
elements. The fix addresses the issue.

This PR is a new implementation of https://github.com/strongloop/strong-soap/pull/99

### Description


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #99 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
