### PR TITLE
Load WSDL files from the cache

### DIFF
--- a/test/wsdl-load-from-memory-test.js
+++ b/test/wsdl-load-from-memory-test.js
@@ -1,0 +1,116 @@
+"use strict";
+
+var fs = require('fs'),
+    soap = require('..').soap,
+    WSDL = soap.WSDL,
+    assert = require('assert'),
+    path = require('path');
+
+describe('wsdl-load-from-memory-tests', function() {
+
+  describe('should load the wsdl from memory', function () {
+
+    var stockQuoteWsdlContents
+
+    beforeEach(function (done) {
+
+      // Read the contents of the WSDL from the file system
+      fs.readFile(__dirname + '/wsdl/from-memory/stockquote.wsdl', 'utf8', function (err, definition) {
+      if (err) {
+        done(err)
+      } else {
+        stockQuoteWsdlContents = definition;
+        done()
+      }
+      });
+    });
+
+    it('should load a wsdl with no imports directly from memory', function (done) {
+
+      var options = {
+        WSDL_CACHE: {}
+      }
+      // Create the initial wsdl directly
+      var stockQuoteWsdl = new WSDL(stockQuoteWsdlContents, undefined, options)
+
+      // Load the wsdl fully once its been created in memory
+      stockQuoteWsdl.load(function () {
+        assert.equal(stockQuoteWsdl.definitions['$name'], "StockQuote")
+        done()
+      })
+    });
+  });
+
+  describe('should load a multipart wsdl from the cache', function () {
+
+    var options = {
+      WSDL_CACHE: {}
+    }
+
+    beforeEach(function (done) {
+      var filePrefix = __dirname + '/wsdl/from-memory/multipart/';
+      var promiseList = []
+      /**
+       * Read the contents of each of the files from the multipart directory
+       */
+      fs.readdirSync(filePrefix).forEach(function (fileName) {
+        promiseList.push(new Promise(function (resolve, reject) {
+          fs.readFile(filePrefix + fileName, 'utf8', function (err, definition) {
+            if (err) {
+              reject(err)
+            } else {
+              /**
+               * Create a WSDL object for each of the files and store them
+               * in options.WSDL_CACHE. Don't call load() at this point.
+               */
+
+              // This path name isn't the correct one, however it is what the strong-soap
+              // implementation will default to when it comes to checking the cache.
+              var includePath = path.resolve(fileName)
+              var wsdl = new WSDL(definition, includePath, options)
+              options.WSDL_CACHE[includePath] = wsdl
+              wsdl.WSDL_CACHE = options.WSDL_CACHE
+              resolve(wsdl)
+            }
+          })
+        }))
+      });
+      Promise.all(promiseList).then(function (values) {
+        done();
+      })
+
+    });
+
+    it('a multipart wsdl should load from the cache with no errors', function(done){
+      /**
+       * Read in a file wsdl file containing a definition. For the purpose of this test this file should be one that is
+       * in the WSDL_CACHE already, but loaded from a different location. The reason for the different location is that
+       * the this will show that the additional wsdls and xsd files are being read from the cache and not just from the
+       * relative path on the file system.
+       */
+       fs.readFile(__dirname + '/wsdl/from-memory/main.wsdl', 'utf8', function (err, definition) {
+
+         assert.ok(!err);
+         /**
+          * Load the starting point wsdl from memory. Put in an incorrect uri as this should be loaded from the CACHE
+          */
+         var wsdlDefinition = new WSDL(definition, 'startingWsdlUri', options)
+
+         /**
+          * The load() function should take into account wsdls which have had their definitions loaded into the WSDL_CACHE,
+          * but still needs to be fully parsed and loaded.
+          */
+         wsdlDefinition.load(function (err, loadedWsdl) {
+           assert.ok(!err);
+           assert(loadedWsdl);
+           assert(loadedWsdl.definitions);
+           assert.notDeepEqual(loadedWsdl.definitions.bindings, {}, "Bindings not loaded on wsdl");
+           assert.notDeepEqual(loadedWsdl.definitions.services, {}, "Services not loaded on wsdl");
+           assert.notDeepEqual(loadedWsdl.definitions.portTypes, {}, "PortTypes not loaded on wsdl");
+           done();
+         })
+      })
+    })
+  });
+});
+

--- a/test/wsdl/from-memory/main.wsdl
+++ b/test/wsdl/from-memory/main.wsdl
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions name="UserRemoteServiceImplService"
+                  targetNamespace="http://base.example.com"
+                  xmlns:ns1="http://example.com/"
+                  xmlns:ns2="http://cxf.apache.org/bindings/xformat"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:tns="http://base.example.com"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <wsdl:import location="sub.wsdl" namespace="http://example.com/">
+    </wsdl:import>
+    <wsdl:binding name="UserRemoteServiceImplServiceSoapBinding"
+                  type="ns1:IUserRemoteService">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="getLatestVersion">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="getLatestVersion">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="getLatestVersionResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+
+    </wsdl:binding>
+    <wsdl:service name="UserRemoteServiceImplService">
+        <wsdl:port binding="tns:UserRemoteServiceImplServiceSoapBinding"
+                   name="UserRemoteServiceImplPort">
+            <soap:address location="http://example.com/ws/UserRemoteService"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/wsdl/from-memory/multipart/main.wsdl
+++ b/test/wsdl/from-memory/multipart/main.wsdl
@@ -1,0 +1,33 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions name="UserRemoteServiceImplService"
+                  targetNamespace="http://base.example.com"
+                  xmlns:ns1="http://example.com/"
+                  xmlns:ns2="http://cxf.apache.org/bindings/xformat"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:tns="http://base.example.com"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <wsdl:import location="sub.wsdl" namespace="http://example.com/">
+    </wsdl:import>
+    <wsdl:binding name="UserRemoteServiceImplServiceSoapBinding"
+                  type="ns1:IUserRemoteService">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="getLatestVersion">
+            <soap:operation soapAction="" style="document"/>
+            <wsdl:input name="getLatestVersion">
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output name="getLatestVersionResponse">
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+
+    </wsdl:binding>
+    <wsdl:service name="UserRemoteServiceImplService">
+        <wsdl:port binding="tns:UserRemoteServiceImplServiceSoapBinding"
+                   name="UserRemoteServiceImplPort">
+            <soap:address location="http://example.com/ws/UserRemoteService"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/wsdl/from-memory/multipart/sub.wsdl
+++ b/test/wsdl/from-memory/multipart/sub.wsdl
@@ -1,0 +1,48 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<wsdl:definitions name="IUserRemoteService"
+                  targetNamespace="http://example.com/"
+                  xmlns:ns1="http://example.com/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <wsdl:types>
+        <xs:schema elementFormDefault="unqualified"
+                   targetNamespace="http://example.com/" version="1.0"
+                   xmlns:tns="http://example.com/"
+                   xmlns:xs="http://www.w3.org/2001/XMLSchema">
+            <xs:import schemaLocation="xsd.xsd"
+                       namespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"/>
+
+            <xs:element name="getLatestVersion" type="tns:getLatestVersion"/>
+            <xs:element name="getLatestVersionResponse"
+                        type="tns:getLatestVersionResponse"/>
+
+            <xs:complexType name="getLatestVersion">
+                <xs:sequence/>
+            </xs:complexType>
+            <xs:complexType name="getLatestVersionResponse">
+                <xs:sequence>
+                    <xs:element minOccurs="0" name="return" type="xs:long"/>
+                </xs:sequence>
+            </xs:complexType>
+
+        </xs:schema>
+    </wsdl:types>
+    <wsdl:message name="getLatestVersion">
+        <wsdl:part element="ns1:getLatestVersion" name="parameters">
+        </wsdl:part>
+    </wsdl:message>
+    <wsdl:message name="getLatestVersionResponse">
+        <wsdl:part element="ns1:getLatestVersionResponse"
+                   name="parameters"></wsdl:part>
+    </wsdl:message>
+    <wsdl:portType name="IUserRemoteService">
+        <wsdl:operation name="getLatestVersion">
+            <wsdl:input message="ns1:getLatestVersion" name="getLatestVersion">
+            </wsdl:input>
+            <wsdl:output message="ns1:getLatestVersionResponse"
+                         name="getLatestVersionResponse">
+            </wsdl:output>
+        </wsdl:operation>
+
+    </wsdl:portType>
+</wsdl:definitions>

--- a/test/wsdl/from-memory/multipart/xsd.xsd
+++ b/test/wsdl/from-memory/multipart/xsd.xsd
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xs:schema elementFormDefault="qualified"
+           targetNamespace="http://schemas.microsoft.com/2003/10/Serialization/Arrays"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:tns="http://schemas.microsoft.com/2003/10/Serialization/Arrays">
+    <xs:complexType name="ArrayOfstring">
+        <xs:sequence>
+            <xs:element minOccurs="0" maxOccurs="unbounded" name="string"
+                        nillable="true" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
+    <xs:element name="ArrayOfstring" nillable="true" type="tns:ArrayOfstring"/>
+</xs:schema>

--- a/test/wsdl/from-memory/stockquote.wsdl
+++ b/test/wsdl/from-memory/stockquote.wsdl
@@ -1,0 +1,108 @@
+<?xml version="1.0"?>
+
+<wsdl:definitions name="StockQuote"
+                  targetNamespace="http://example.com/stockquote.wsdl"
+                  xmlns:tns="http://example.com/stockquote.wsdl"
+                  xmlns:xsd1="http://example.com/stockquote.xsd"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/">
+
+    <wsdl:types>
+        <xsd:schema targetNamespace="http://example.com/stockquote.xsd"
+                    xmlns:xsd="http://www.w3.org/2000/10/XMLSchema">
+            <xsd:element name="TradePriceRequest">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="tickerSymbol" type="xsd:string"/>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="TradePrice">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="price" type="xsd:float"/>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="TradePriceSubmit">
+                <xsd:complexType>
+                    <xsd:all>
+                        <xsd:element name="tickerSymbol" type="xsd:string"/>
+                        <xsd:element name="price" type="xsd:float"/>
+                    </xsd:all>
+                </xsd:complexType>
+            </xsd:element>
+            <xsd:element name="valid" type="xsd:boolean"/>
+        </xsd:schema>
+    </wsdl:types>
+
+    <wsdl:message name="GetLastTradePriceInput">
+        <wsdl:part name="body" element="xsd1:TradePriceRequest"/>
+    </wsdl:message>
+
+    <wsdl:message name="GetLastTradePriceOutput">
+        <wsdl:part name="body" element="xsd1:TradePrice"/>
+    </wsdl:message>
+
+    <wsdl:message name="SetTradePriceInput">
+        <wsdl:part name="body" element="xsd1:TradePriceSubmit"/>
+    </wsdl:message>
+
+    <wsdl:message name="IsValidPriceInput">
+        <wsdl:part name="body" element="xsd1:TradePrice"/>
+    </wsdl:message>
+
+    <wsdl:message name="IsValidPriceOutput">
+        <wsdl:part name="body" element="xsd1:valid"/>
+    </wsdl:message>
+
+    <wsdl:portType name="StockQuotePortType">
+        <wsdl:operation name="GetLastTradePrice">
+            <wsdl:input message="tns:GetLastTradePriceInput"/>
+            <wsdl:output message="tns:GetLastTradePriceOutput"/>
+        </wsdl:operation>
+        <wsdl:operation name="SetTradePrice">
+            <wsdl:input message="tns:SetTradePriceInput"/>
+        </wsdl:operation>
+        <wsdl:operation name="IsValidPrice">
+            <wsdl:input message="tns:IsValidPriceInput"/>
+            <wsdl:output message="tns:IsValidPriceOutput"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+    <wsdl:binding name="StockQuoteSoapBinding" type="tns:StockQuotePortType">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="GetLastTradePrice">
+            <soap:operation soapAction="http://example.com/GetLastTradePrice"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+        <wsdl:operation name="SetTradePrice">
+            <soap:operation soapAction="http://example.com/SetTradePrice"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+        </wsdl:operation>
+        <wsdl:operation name="IsValidPrice">
+            <soap:operation soapAction="http://example.com/IsValidPrice"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="StockQuoteService">
+        <wsdl:port name="StockQuotePort" binding="tns:StockQuoteSoapBinding">
+            <soap:address location="http://localhost:15099/stockquote"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>


### PR DESCRIPTION
### Description
We discussed with @raymondfeng the idea of being able to load WSDL files from memory into strong-soap (as opposed to from a file system or a url). Reymond suggested making use of the existing loading structure (as used by `WSDL.open(...)` ), which can be described as:
1) Read the contents of the file form the file system/url.
2) Create a WSDL object using the `var wsdl = new WSDL(definition....)` constructor.
3) Perform a `load()` on this object to process the contents of the wsdl, using `wsdl.load(....)`

There are 2 usecases that this PR is aiming to cover.
1) Load a single wsdl file from memory.
2) Load a multipart wsdl (a collection of wsdls and xsd files) from memory.

Usecase 1) could be achieved by the current `strong-soap` functionality, so to achieve this all this PR does it to add a new test to demonstrate it.

Usecase 2) could technically be achieved by the current `strong-soap` functionality by reading the files from the file system, creating WSDL objects from them, loading each object into `options.WSDL_CACHE`, then calling `load()`. The problem was that the order these objects were loaded in was important and the load would fail if they were done in the wrong order. The implication of this was the in order to be able to dynamically load a multipart wsdl into `strong-soap`, the user would be required to parse the tree structure then call `load()` in the correct order (which is one of the jobs that `strong-soap` was already doing for free).

As a result this PR makes some small updates to the loading processes in order to recognize WSDLs which have been added to the cache, but not had `load()` called against them. If any of these are found then `load()` will be called. This is done by the introduction of an `isLoaded` flag which will get set in the objects `load()` function.

The files used in the tests are ones already present in this repository, however, in order to keep this test self contained, they have been copied to the directory `wsdl/from-memory`

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
