### PR TITLE
add forgotten options to soap.listen(...)

### DIFF
--- a/src/soap.js
+++ b/src/soap.js
@@ -64,7 +64,7 @@ function listen(server, pathOrOptions, services, xml) {
   }
 
   var wsdl = new parser.WSDL(xml || services, uri, options);
-  return new Server(server, path, services, wsdl);
+  return new Server(server, path, services, wsdl, options);
 }
 
 exports.security = security;


### PR DESCRIPTION
### Description

soap.listen doesn't handle wsdl options like 'attributesKey', etc
PR is a one-line fix for this issue

Question: why is default value for attributesKey for server is 'attributes', not '$attributes'? Found in src/base.js
