### PR TITLE
Create client from cached wsdl

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,44 @@ soap.createClient(url, options, function(err, client) {
 
 ```
 
+As well as creating a client via a `url`, an existing [WSDL](#wsdl) object can be passed in via `options.WSDL_CACHE`.
+
+```
+var soap = require('strong-soap').soap;
+var WSDL = soap.WSDL;
+
+var url = 'http://www.webservicex.net/stockquote.asmx?WSDL';
+
+// Pass in WSDL options if any
+
+var options = {};
+WSDL.open(url,options,
+  function(err, wsdl) {
+    // You should be able to get to any information of this WSDL from this object. Traverse
+    // the WSDL tree to get  bindings, operations, services, portTypes, messages,
+    // parts, and XSD elements/Attributes.
+
+    // Set the wsdl object in the cache. The key (e.g. 'stockquotewsdl')
+    // can be anything, but needs to match the parameter passed into soap.createClient()
+    var clientOptions = {
+      WSDL_CACHE : {
+        stockquotewsdl: wsdl
+      }
+    };
+    soap.createClient('stockquotewsdl', clientOptions, function(err, client) {
+      var method = client['StockQuote']['StockQuoteSoap']['GetQuote'];
+      method(requestArgs, function(err, result, envelope, soapHeader) {
+
+      //response envelope
+      console.log('Response Envelope: \n' + envelope);
+      //'result' is the response body
+      console.log('Result: \n' + JSON.stringify(result));
+    });
+  });
+});
+```
+
+
 The Request envelope created by above service invocation:
 
 ```

--- a/src/soap.js
+++ b/src/soap.js
@@ -16,6 +16,7 @@ function _requestWSDL(url, options, callback) {
     callback = options;
     options = {};
   }
+  _wsdlCache = options.WSDL_CACHE || _wsdlCache;
 
   var wsdl = _wsdlCache[url];
   if (wsdl) {


### PR DESCRIPTION
### Description
Building on the functionality introduced in PR https://github.com/strongloop/strong-soap/pull/168 which allowed for `WSDL` objects to be created from files in memory, this PR allows for a client to be created from a `WSDL` in memory as opposed to just a URL or reference to a file system.

This uses the same idea as is used for creating a `WSDL` i.e. the options that are passed to the client can include a pre-populated cached object called `options.WSDL_CACHE`. If the wsdl is found in  `options.WSDL_CACHE` then it will be used (the client already uses a cache to look for wsdls, it just starts out empty), if not then the current behavior will continue.

#### Related issues
https://github.com/strongloop/strong-soap/pull/168
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
