### PR TITLE
Allow documentation tag under types

### DIFF
--- a/src/parser/wsdl/types.js
+++ b/src/parser/wsdl/types.js
@@ -3,6 +3,7 @@
 var WSDLElement = require('./wsdlElement');
 var assert = require('assert');
 var Schema = require('../xsd/schema');
+var Documentation = require('./documentation');
 
 class Types extends WSDLElement {
   constructor(nsName, attrs, options) {
@@ -11,16 +12,19 @@ class Types extends WSDLElement {
   }
 
   addChild(child) {
-    assert(child instanceof Schema);
+    assert(child instanceof Schema || child instanceof Documentation);
 
-    var targetNamespace = child.$targetNamespace;
+    if (child instanceof Schema) {
 
-    if (!this.schemas.hasOwnProperty(targetNamespace)) {
-      this.schemas[targetNamespace] = child;
-    } else {
-      // types might have multiple schemas with the same target namespace,
-      // including no target namespace
-      this.schemas[targetNamespace].merge(child, true);
+      var targetNamespace = child.$targetNamespace;
+
+      if (!this.schemas.hasOwnProperty(targetNamespace)) {
+        this.schemas[targetNamespace] = child;
+      } else {
+        // types might have multiple schemas with the same target namespace,
+        // including no target namespace
+        this.schemas[targetNamespace].merge(child, true);
+      }
     }
   };
 }

--- a/test/wsdl/wsdlImport/sub.wsdl
+++ b/test/wsdl/wsdlImport/sub.wsdl
@@ -5,6 +5,7 @@
                   xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
                   xmlns:xsd="http://www.w3.org/2001/XMLSchema">
     <wsdl:types>
+       <wsdl:documentation>Add some details about these types.</wsdl:documentation>
         <xs:schema elementFormDefault="unqualified"
                    targetNamespace="http://example.com/" version="1.0"
                    xmlns:tns="http://example.com/"


### PR DESCRIPTION
### Description
When trying to create a client from a wsdl which has a `wsdl:documentation` tag under the `wsdl:types` element 

```
  <wsdl:types>
    <wsdl:documentation>WSDL Documentation example</wsdl:documentation>
    <s:schema elementFormDefault="unqualified" targetNamespace="http://www.ibm.com/soap11wsdl" xmlns:s1="http://www.ibm.com/schema1">
...
```
strong-soap failed with the following error:
```
AssertionError [ERR_ASSERTION]: false == true
Expected :true
Actual   :false
 <Click to see difference>

    at Types.addChild (node_modules\strong-soap\src\parser\wsdl\types.js:14:5)
    at Documentation.endElement (node_modules\strong-soap\src\parser\element.js:109:16)
    at SAXParser.p.onclosetag (node_modules\strong-soap\src\parser\wsdl.js:299:11)
    at emit (node_modules\sax\lib\sax.js:624:35)
    at emitNode (node_modules\sax\lib\sax.js:629:5)
    at closeTag (node_modules\sax\lib\sax.js:889:7)
    at SAXParser.write (node_modules\sax\lib\sax.js:1436:13)
    at WSDL._parse (node_modules\strong-soap\src\parser\wsdl.js:307:7)
    at WSDL._fromXML (node_modules\strong-soap\src\parser\wsdl.js:313:29)
    at C:\AppConnect\loopback-connector-soapwsdl\node_modules\strong-soap\src\parser\wsdl.js:55:18
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

It looks like the `types` element is expecting that a `documentation` tag should be valid: https://github.com/strongloop/strong-soap/blob/09b1cfdd9582a592874c09fa47f5f301d2ed2ae2/src/parser/wsdl/types.js#L29

This also matches what the WSDL spec says under section [2.1 WSDL Document Structure](https://www.w3.org/TR/2001/NOTE-wsdl-20010315#_types):
```
    <wsdl:types> ?
        <wsdl:documentation .... />?
        <xsd:schema .... />*
        <-- extensibility element --> *
    </wsdl:types>
```

This PR updates the failing assert statement to allow a `documentation` element to be included under `types`. 

#### Related issues
There is an older strong-soap PR commit which started to address this: https://github.com/strongloop/strong-soap/commit/2b161e8eeb03cbf83398b9cd9afe774b4aff693b

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
