### PR TITLE
fix: use proper variable names

### DIFF
--- a/example/xsds.js
+++ b/example/xsds.js
@@ -6,7 +6,7 @@ var path = require('path');
 //user can pass in WSDL options
 var options = {};
 
-WSDL.open('./wsdls/weather.wsdl', options,
+WSDL.open(path.resolve(__dirname, 'wsdls/weather.wsdl'), options,
   //User can traverse the WSDL tree and get to bindings - > operations, services, portTypes, messages, parts and XSD elements/Attributes
   function(err, wsdl) {
     var getCityForecastOp = wsdl.definitions.bindings.WeatherSoap.operations.GetCityForecastByZIP;

--- a/src/parser/xsd/element.js
+++ b/src/parser/xsd/element.js
@@ -52,7 +52,7 @@ class Element extends XSDElement {
         if (typeDescriptor) {
           descriptor.elements = typeDescriptor.elements;
           descriptor.attributes = typeDescriptor.attributes;
-          definitions.mixed = typeDescriptor.mixed;
+          descriptor.mixed = typeDescriptor.mixed;
           descriptor.extension = typeDescriptor.extension;
           if(descriptor.extension && descriptor.extension.isSimple === true) {
             descriptor.isSimple = true;
@@ -73,7 +73,7 @@ class Element extends XSDElement {
           if (childDescriptor) {
             descriptor.elements = childDescriptor.elements;
             descriptor.attributes = childDescriptor.attributes;
-            definitions.mixed = childDescriptor.mixed;
+            descriptor.mixed = childDescriptor.mixed;
           }
           break;
         } else if (child instanceof SimpleType) {


### PR DESCRIPTION
### Description

Fix to use proper variable names. Those using complex WSDLs will probably run into this issue with the following error:
```
/Users/badmike/loopback/strong-soap/example/json2xmlwithschema.js:57
      ].children[1].describe(wsdl.definitions),
        ^

TypeError: Cannot read property 'children' of undefined
    at /Users/badmike/loopback/strong-soap/example/json2xmlwithschema.js:57:9
    at /Users/badmike/loopback/strong-soap/src/parser/wsdl.js:105:9
    at WSDL._processNextInclude (/Users/badmike/loopback/strong-soap/src/parser/wsdl.js:162:14)
    at WSDL.processIncludes (/Users/badmike/loopback/strong-soap/src/parser/wsdl.js:221:10)
    at /Users/badmike/loopback/strong-soap/src/parser/wsdl.js:60:12
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
    at process._tickCallback (internal/process/next_tick.js:180:9)
```

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
