### PR TITLE
Force sync load

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,18 @@ WSDL.open('./wsdls/stockquote.wsdl',options,
 });
 ```
 
+### wsdl.openSync(wsdlURL, options)
+
+Loads WSDL into a tree form directly from memory. It traverses through WSDL tree to get to bindings, services, ports, operations, and so on as long as you have your dependent WSDLs and schemas are loaded and available in the `options.WSDL_CACHE`. If any I/O is required to retrieve any dependencies this call will throw an error.
+
+Parameters:
+
+- `wsdlURL` WSDL url to load as named in the cache.
+- `options` WSDL options
+
+An example of loading WSDLs into your `options.WSDL_CACHE` and calling `wsdl.loadSync()` can be found in the test [test/wsdl-load-from-memory-test](https://github.com/strongloop/strong-soap/tree/master/test/wsdl-load-from-memory-test.js)
+
+
 ## Server
 
 ### soap.listen(*server*, *path*, *services*, *wsdl*)

--- a/test/wsdl-load-from-memory-test.js
+++ b/test/wsdl-load-from-memory-test.js
@@ -10,19 +10,40 @@ describe('wsdl-load-from-memory-tests', function() {
 
   describe('should load the wsdl from memory', function () {
 
-    var stockQuoteWsdlContents
+    var stockQuoteWsdlContents;
+    var mainWsdlContents;
 
     beforeEach(function (done) {
 
-      // Read the contents of the WSDL from the file system
-      fs.readFile(__dirname + '/wsdl/from-memory/stockquote.wsdl', 'utf8', function (err, definition) {
-      if (err) {
-        done(err)
-      } else {
-        stockQuoteWsdlContents = definition;
-        done()
-      }
-      });
+      var promiseList = [];
+
+      promiseList.push(new Promise(function (resolve, reject) {
+        fs.readFile(__dirname + '/wsdl/from-memory/stockquote.wsdl', 'utf8', function (err, definition) {
+          if (err) {
+            reject(err);
+          } else {
+            stockQuoteWsdlContents = definition;
+            resolve(stockQuoteWsdlContents);
+          }
+        })
+      }));
+
+      promiseList.push(new Promise(function (resolve, reject) {
+        fs.readFile(__dirname + '/wsdl/from-memory/main.wsdl', 'utf8', function (err, definition) {
+          if (err) {
+            reject(err)
+          } else {
+            mainWsdlContents = definition;
+            resolve(mainWsdlContents)
+          }
+        })
+      }));
+
+      Promise.all(promiseList).then(function () {
+        done();
+      })
+
+
     });
 
     it('should load a wsdl with no imports directly from memory', function (done) {
@@ -35,9 +56,43 @@ describe('wsdl-load-from-memory-tests', function() {
 
       // Load the wsdl fully once its been created in memory
       stockQuoteWsdl.load(function () {
-        assert.equal(stockQuoteWsdl.definitions['$name'], "StockQuote")
-        done()
+        assert.equal(stockQuoteWsdl.definitions['$name'], "StockQuote");
+        done();
       })
+    });
+
+    it('should load a wsdl synchronously with no imports directly from memory or should honour synchronous loading of a wsdl', function (done) {
+
+      var options = {
+        WSDL_CACHE: {}
+      };
+      // Create the initial wsdl directly
+      var stockQuoteWsdl = new WSDL(stockQuoteWsdlContents, undefined, options);
+
+      // Load the wsdl fully once its been created in memory in a sync manner
+      var checkwsdl = stockQuoteWsdl.loadSync();
+      assert.equal(checkwsdl.definitions['$name'], "StockQuote");
+      done();
+    });
+
+    it('should fail to load a wsdl synchronously as wsdl not present in memory', function (done) {
+
+      var options = {
+        WSDL_CACHE: {}
+      };
+      // Create the initial wsdl directly
+      var mainWsdl = new WSDL(mainWsdlContents, undefined, options);
+
+      // Load the wsdl fully once its been created in memory in a sync manner which will fail as there
+      // are unresolved imports which would need I/O to resolve
+      try {
+        var checkwsdl = mainWsdl.loadSync();
+      } catch(err) {
+        console.log(err)
+        // check error thrown
+        assert.ok(err.indexOf('For loadSync() calls all schemas must be preloaded into the cache') > -1 );
+        done();
+      }
     });
   });
 
@@ -49,7 +104,7 @@ describe('wsdl-load-from-memory-tests', function() {
 
     beforeEach(function (done) {
       var filePrefix = __dirname + '/wsdl/from-memory/multipart/';
-      var promiseList = []
+      var promiseList = [];
       /**
        * Read the contents of each of the files from the multipart directory
        */
@@ -57,7 +112,7 @@ describe('wsdl-load-from-memory-tests', function() {
         promiseList.push(new Promise(function (resolve, reject) {
           fs.readFile(filePrefix + fileName, 'utf8', function (err, definition) {
             if (err) {
-              reject(err)
+              reject(err);
             } else {
               /**
                * Create a WSDL object for each of the files and store them
@@ -66,16 +121,16 @@ describe('wsdl-load-from-memory-tests', function() {
 
               // This path name isn't the correct one, however it is what the strong-soap
               // implementation will default to when it comes to checking the cache.
-              var includePath = path.resolve(fileName)
-              var wsdl = new WSDL(definition, includePath, options)
-              options.WSDL_CACHE[includePath] = wsdl
-              wsdl.WSDL_CACHE = options.WSDL_CACHE
-              resolve(wsdl)
+              var includePath = path.resolve(fileName);
+              var wsdl = new WSDL(definition, includePath, options);
+              options.WSDL_CACHE[includePath] = wsdl;
+              wsdl.WSDL_CACHE = options.WSDL_CACHE;
+              resolve(wsdl);
             }
           })
         }))
       });
-      Promise.all(promiseList).then(function (values) {
+      Promise.all(promiseList).then(function () {
         done();
       })
 
@@ -94,7 +149,7 @@ describe('wsdl-load-from-memory-tests', function() {
          /**
           * Load the starting point wsdl from memory. Put in an incorrect uri as this should be loaded from the CACHE
           */
-         var wsdlDefinition = new WSDL(definition, 'startingWsdlUri', options)
+         var wsdlDefinition = new WSDL(definition, 'startingWsdlUri', options);
 
          /**
           * The load() function should take into account wsdls which have had their definitions loaded into the WSDL_CACHE,
@@ -111,6 +166,37 @@ describe('wsdl-load-from-memory-tests', function() {
          })
       })
     })
+
+
+    it('a multipart wsdl should load from the cache in a sync way with no errors', function(done){
+      /**
+       * Read in a file wsdl file containing a definition. For the purpose of this test this file should be one that is
+       * in the WSDL_CACHE already, but loaded from a different location. The reason for the different location is that
+       * the this will show that the additional wsdls and xsd files are being read from the cache and not just from the
+       * relative path on the file system.
+       */
+      fs.readFile(__dirname + '/wsdl/from-memory/main.wsdl', 'utf8', function (err, definition) {
+
+        assert.ok(!err);
+        /**
+         * Load the starting point wsdl from memory. Put in an incorrect uri as this should be loaded from the CACHE
+         */
+        var wsdlDefinition = new WSDL(definition, 'startingWsdlUri', options);
+
+        /**
+         * The load() function should take into account wsdls which have had their definitions loaded into the WSDL_CACHE,
+         * but still needs to be fully parsed and loaded.
+         */
+        var loadedWsdl = wsdlDefinition.loadSync();
+        assert(loadedWsdl);
+        assert(loadedWsdl.definitions);
+        assert.notDeepEqual(loadedWsdl.definitions.bindings, {}, "Bindings not loaded on wsdl");
+        assert.notDeepEqual(loadedWsdl.definitions.services, {}, "Services not loaded on wsdl");
+        assert.notDeepEqual(loadedWsdl.definitions.portTypes, {}, "PortTypes not loaded on wsdl");
+        done();
+      })
+    })
+
   });
 });
 


### PR DESCRIPTION
### Description
Within our product we need the WSDL.load to be called in a sync manner and as this call is async we need an option to be able to call it sync. We will be supplying all wsdls in memory so will not have any I/O.

https://nodejs.org/api/process.html#process_process_nexttick_callback_args

#### Related issues
Will use the changes here https://github.com/strongloop/strong-soap/pull/172 to provide all wsdls in memory

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)

**Test run**
	File                           |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |

	 Original (master)
	 wsdl.js                      |       85 |    72.54 |    73.33 |    85.66 |... 72,473,489,490 |
	 
	 With additional test (forceSyncLoad) 
	 wsdl.js                      |    85.38 |    73.24 |    73.33 |    86.05 |... 72,473,489,490 |

