### PR TITLE
Is many logic

### DIFF
--- a/src/parser/xsd/xsdElement.js
+++ b/src/parser/xsd/xsdElement.js
@@ -8,7 +8,7 @@ class XSDElement extends Element {
   constructor(nsName, attrs, options) {
     super(nsName, attrs, options);
   }
-  
+
   describeChildren(definitions, descriptor) {
     var children = this.children || [];
     if (children.length === 0) return descriptor;
@@ -39,7 +39,7 @@ class XSDElement extends Element {
    */
   isMany() {
     if (this.$maxOccurs === 'unbounded') return true;
-    return Number(this.$maxOccurs) > 0;
+    return Number(this.$maxOccurs) > 1;
   }
 }
 

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -6,7 +6,10 @@ var fs = require('fs'),
     should = require('should'),
     request = require('request'),
     http = require('http'),
-    async = require('async');
+    async = require('async'),
+    path = require('path');
+
+var openWSDL = require('..').WSDL.open;
 
 describe('wsdl-tests', function() {
 
@@ -177,6 +180,32 @@ describe('wsdl-tests', function() {
         var schema = client.wsdl.definitions.schemas['http://www.dummy.com/Types'];
         var simpleTypes = Object.keys(schema.simpleTypes);
         simpleTypes.should.eql(['IdType', 'NameType', 'AnotherIdType'])
+        done();
+      });
+    });
+
+    it('should map isMany values correctly', function(done) {
+      openWSDL(path.resolve(__dirname, 'wsdl/marketo.wsdl'), function(
+        err,
+        def
+      ) {
+        var operation = def.definitions.bindings.MktowsApiSoapBinding.operations.getLeadChanges;
+        var operationDesc = operation.describe(def);
+        assert(operationDesc.input.body.elements[0].elements);
+
+        // Check that an element with maxOccurs="1" maps to isMany = false
+        operationDesc.input.body.elements[0].elements.forEach(function(element){
+          if(element.qname.name === 'startPosition'){
+            assert.equal(element.isMany, false);
+          }
+
+          // Check that an element with maxOccurs="unbounded" maps to isMany = false
+          if(element.qname.name === 'activityNameFilter'){
+            assert(element.elements[0]);
+            assert.equal(element.elements[0].isMany, true);
+          }
+        });
+
         done();
       });
     });


### PR DESCRIPTION
### Description
When using the operation `describe()` function to inspect details of an operation and its elements, the `isMany` property is used to determine if multiple occurrences of an element can be included. Currently if an element looks like `<element maxOccurs="1" minOccurs="0" name="town" type="xsd:string"/>` strong-soap is still setting `isMany` to be true. This should be false as the element says that no more than one instance can be present.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
