### PR TITLE
Update version of httpntlm

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "compress": "^0.99.0",
     "debug": "^3.1.0",
-    "httpntlm": "^1.6.1",
+    "httpntlm": "^1.7.6",
     "lodash": "^4.13.1",
     "optional": "^0.1.3",
     "path": "^0.12.7",


### PR DESCRIPTION
### Description
The package that `strong-soap` uses to make NTLM requests (https://www.npmjs.com/package/httpntlm) included a fix in v1.7.6 which addressed an issue with making NTLM requests while using TLS. 

This PR increases the version of `httpntlm` required by strong-soap to make sure that this version is picked up.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
