### PR TITLE
Fix use options.request in wsdl.js

### DIFF
--- a/src/parser/wsdl.js
+++ b/src/parser/wsdl.js
@@ -164,6 +164,10 @@ class WSDL {
     if (options.httpClient) {
       this.options.httpClient = options.httpClient;
     }
+    
+    if (options.request) {
+      this.options.request = options.request;
+    }
 
     var ignoreBaseNameSpaces = options ? options.ignoreBaseNameSpaces : null;
     if (ignoreBaseNameSpaces !== null &&


### PR DESCRIPTION
### Description
options.request was not used when retrieving sub-schemas.