### PR TITLE
Added stubs for testing when using promise returns instead of callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -892,6 +892,10 @@ var clientStub = {
 
 clientStub.SomeOperation.respondWithError = soapStub.createRespondingStub({error: 'error'});
 clientStub.SomeOperation.respondWithSuccess = soapStub.createRespondingStub({success: 'success'});
+// or if you are using promises
+clientStub.SomeOperation.respondWithError = soapStub.createRespondingStubAsync({error: 'error'});
+clientStub.SomeOperation.respondWithSuccess = soapStub.createRespondingStubAsync({success: 'success'});
+
 
 soapStub.registerClient('my client alias', urlMyApplicationWillUseWithCreateClient, clientStub);
 

--- a/soap-stub.js
+++ b/soap-stub.js
@@ -21,7 +21,9 @@ var clientStubs = {};
 module.exports = {
   createClient: createClient,
   createErroringStub: createErroringStub,
+  createErroringStubAsync: createErroringStubAsync,
   createRespondingStub: createRespondingStub,
+  createRespondingStubAsync: createRespondingStubAsync,
   errOnCreateClient: false,
   getStub: getStub,
   registerClient: registerClient,
@@ -83,6 +85,30 @@ function createErroringStub(err) {
 }
 
 /**
+ * Returns a method that rejects all promises given to the method it is attached
+ * to with the given error.
+ *
+ * <pre>
+ * myClientStub.someMethod.errorOnCall = createErroringStubAsync(error);
+ *
+ * // elsewhere
+ *
+ * myClientStub.someMethod.errorOnCall();
+ * </pre>
+ *
+ * @param {?} object anything
+ * @return {Function}
+ */
+function createErroringStubAsync(err) {
+  return function() {
+    this.args.forEach(function(argSet) {
+      setTimeout(argSet[1].bind(null, err));
+    });
+    this.rejects(err);
+  };
+}
+
+/**
  * Returns a method that calls all callbacks given to the method it is attached
  * to with the given response.
  *
@@ -103,6 +129,30 @@ function createRespondingStub(object) {
       setTimeout(argSet[1].bind(null, null, object));
     });
     this.yields(null, object);
+  };
+}
+
+/**
+ * Returns a method that resolves all promises given to the method it is attached
+ * to with the given response.
+ *
+ * <pre>
+ * myClientStub.someMethod.respondWithError = createRespondingStubAsync(errorResponse);
+ *
+ * // elsewhere
+ *
+ * myClientStub.someMethod.respondWithError();
+ * </pre>
+ *
+ * @param {?} object anything
+ * @return {Function}
+ */
+function createRespondingStubAsync(object) {
+  return function() {
+    this.args.forEach(function(argSet) {
+      setTimeout(argSet[1].bind(null, null, object));
+    });
+    this.resolves(object);
   };
 }
 


### PR DESCRIPTION
### Description
This makes it possible to test when using promise returns on methods instead of just callbacks (no tests needed)

### Checklist
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
