### PR TITLE
Fix for xs:date with tz format

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -824,9 +824,10 @@ function parseValue(text, descriptor) {
   var jsType = descriptor && descriptor.jsType;
   if (jsType === Date) {
     var dateText = text;
-    // Checks for xs:date with tz 
-    // (examples: 2019-03-26Z or 2019-03-26-06:00)
-    if(dateText.endsWith('Z') || dateText.length === 16){
+    // Checks for xs:date with tz, drops the tz 
+    // because xs:date doesn't have a time to offset
+    // and JS Date object doesn't store an arbitrary tz
+    if(dateText.length === 16){
       dateText = text.substr(0, 10);
     }
     value = new Date(dateText);
@@ -843,3 +844,5 @@ function parseValue(text, descriptor) {
 }
 
 module.exports = XMLHandler;
+// Exported function for testing
+module.exports.parseValue = parseValue;

--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -823,7 +823,13 @@ function parseValue(text, descriptor) {
   var value = text;
   var jsType = descriptor && descriptor.jsType;
   if (jsType === Date) {
-    value = new Date(text);
+    var dateText = text;
+    // Checks for xs:date with tz 
+    // (examples: 2019-03-26Z or 2019-03-26-06:00)
+    if(dateText.endsWith('Z') || dateText.length === 16){
+      dateText = text.substr(0, 10);
+    }
+    value = new Date(dateText);
   } else if (jsType === Boolean) {
     if (text === 'true') {
       value = true;

--- a/test/xs-date-format-test.js
+++ b/test/xs-date-format-test.js
@@ -1,0 +1,43 @@
+"use strict";
+var xmlHandler = require('./../src/parser/xmlHandler');
+var assert = require('assert');
+
+describe('xs-date-format-tests', function() {
+
+  it('parses a xs:date string with negative tz offset', function () {
+    var inputDate = '2019-03-27-06:00';
+    var parsed = xmlHandler.parseValue(inputDate, {jsType: Date});
+    assert.equal(parsed.toISOString(), new Date('2019-03-27').toISOString(), 'expected parsed date');
+  });
+
+  it('parses a xs:date string with positive tz offset', function () {
+    var inputDate = '2019-03-27+06:00';
+    var parsed = xmlHandler.parseValue(inputDate, {jsType: Date});
+    assert.equal(parsed.toISOString(), new Date('2019-03-27').toISOString(), 'expected parsed date');
+  });
+  
+  it('parses a xs:date string with Z at the end', function () {
+    var inputDate = '2019-03-27Z';
+    var parsed = xmlHandler.parseValue(inputDate, {jsType: Date});
+    assert.equal(parsed.toISOString(), new Date(inputDate).toISOString(), 'expected parsed date');
+  });
+  
+  it('parses a xs:date string without tz', function () {
+    var inputDate = '2019-03-27';
+    var parsed = xmlHandler.parseValue(inputDate, {jsType: Date});
+    assert.equal(parsed.toISOString(), new Date(inputDate).toISOString(), 'expected parsed date');
+  });
+  
+  it('parses a xs:dateTime string with tz', function () {
+    var inputDate = '2019-03-27T01:01:01-03:00';
+    var parsed = xmlHandler.parseValue(inputDate, {jsType: Date});
+    assert.equal(parsed.toISOString(), new Date(inputDate).toISOString(), 'expected parsed date');
+  });
+  
+  it('parses a xs:dateTime string without tz', function () {
+    var inputDate = '2019-03-27T01:01:01';
+    var parsed = xmlHandler.parseValue(inputDate, {jsType: Date});
+    assert.equal(parsed.toISOString(), new Date(inputDate).toISOString(), 'expected parsed date');
+  });
+  
+});


### PR DESCRIPTION
### Description
Hi,

We found that xs:date elements with Timezone are parsed as null, I did this fix for these cases and tested it locally and works.

However, I tried adding a request-response-sample for unit testing but it doesn't run my code, Can you point me in the right direction to add test coverage for this?

#### Related issues

No issues posted

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
