### PR TITLE
Add support for 1/0 booleans

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -843,7 +843,7 @@ function parseValue(text, descriptor) {
     }
     value = new Date(dateText);
   } else if (jsType === Boolean) {
-    if (text === 'true') {
+    if (text === 'true' || text === '1') {
       value = true;
     } else {
       value = false;

--- a/test/xs-boolean-format-test.js
+++ b/test/xs-boolean-format-test.js
@@ -1,0 +1,31 @@
+"use strict";
+var xmlHandler = require('./../src/parser/xmlHandler');
+var assert = require('assert');
+
+describe('xs-boolean-format-tests', function() {
+
+  it('parses a xs:boolean string with literal \'true\'', function () {
+    var inputBoolean = 'true';
+    var parsed = xmlHandler.parseValue(inputBoolean, {jsType: Boolean});
+    assert.equal(parsed, true, 'expected parsed boolean');
+  });
+
+  it('parses a xs:boolean string with literal \'false\'', function () {
+    var inputBoolean = 'false';
+    var parsed = xmlHandler.parseValue(inputBoolean, {jsType: Boolean});
+    assert.equal(parsed, false, 'expected parsed boolean');
+  });
+
+  it('parses a xs:boolean string with literal \'1\'', function () {
+    var inputBoolean = '1';
+    var parsed = xmlHandler.parseValue(inputBoolean, {jsType: Boolean});
+    assert.equal(parsed, true, 'expected parsed boolean');
+  });
+
+  it('parses a xs:boolean string with literal \'0\'', function () {
+    var inputBoolean = '0';
+    var parsed = xmlHandler.parseValue(inputBoolean, {jsType: Boolean});
+    assert.equal(parsed, false, 'expected parsed boolean');
+  });
+
+});


### PR DESCRIPTION
### Description
Current `xmlHandler` only supports booleans as `true`/`false`. This PR is to add support for `1`/`0` as well.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to #218 

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
