### PR TITLE
Replace ursa with node 12 core crypto or node-rsa

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,15 +3,14 @@
   "version": "1.19.1",
   "description": "A minimal node SOAP client",
   "engines": {
-    "node": ">=6.0"
+    "node": ">=8.11.1"
   },
   "dependencies": {
     "compress": "^0.99.0",
     "debug": "^4.1.1",
     "httpntlm": "^1.7.6",
     "lodash": "^4.17.11",
-    "optional": "^0.1.3",
-    "path": "^0.12.7",
+    "node-rsa": "^1.0.5",
     "request": "^2.72.0",
     "sax": "^1.2",
     "selectn": "^1.0.20",
@@ -19,9 +18,6 @@
     "uuid": "^3.2.1",
     "xml-crypto": "^1.4.0",
     "xmlbuilder": "^10.1.1"
-  },
-  "optionalDependencies": {
-    "strong-ursa": "^0.11.0"
   },
   "repository": {
     "type": "git",

--- a/test/security/WSSecurityCert.js
+++ b/test/security/WSSecurityCert.js
@@ -22,7 +22,7 @@ describe('WSSecurityCert', function() {
     if(process.platform === 'win32'){
       return true;
     }
-    var instance = new WSSecurityCert(key, cert, '', 'utf8');
+    var instance = new WSSecurityCert(key, cert, '');
     instance.should.have.property('privateKey');
     instance.should.have.property('publicP12PEM');
     instance.should.have.property('signer');
@@ -36,7 +36,7 @@ describe('WSSecurityCert', function() {
     var passed = true;
 
     try {
-      new WSSecurityCert('*****', cert, '', 'utf8');
+      new WSSecurityCert('*****', cert, '');
     } catch(e) {
       passed = false;
     }
@@ -46,16 +46,6 @@ describe('WSSecurityCert', function() {
     }
 
     passed = true;
-
-    try {
-      new WSSecurityCert(key, cert, '', 'bob');
-    } catch(e) {
-      passed = false;
-    }
-
-    if (passed) {
-      throw new Error('bad encoding');
-    }
   });
 
   it('should insert a WSSecurity signing block when postProcess is called',
@@ -63,7 +53,7 @@ describe('WSSecurityCert', function() {
     if(process.platform === 'win32'){
       return true;
     }
-    var instance = new WSSecurityCert(key, cert, '', 'utf8');
+    var instance = new WSSecurityCert(key, cert, '');
     var env = XMLHandler.createSOAPEnvelope();
     instance.postProcess(env.header, env.body);
     var xml = env.header.toString({pretty: false});


### PR DESCRIPTION
### Description

ursa is an optional binary dependencies and it caused a lot of trouble installing, especially for `loopback-cli`.

This PR replaces ursa with [Node 12 core crypto apis](https://nodejs.org/api/crypto.html) and falls back to [node-rsa](https://github.com/rzcoder/node-rsa).

#### Related issues

https://github.com/strongloop/loopback-cli/issues/87
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
