### PR TITLE
Avoid line feed problems (Win/Linux)

### DIFF
--- a/test/wsdl-parse-test.js
+++ b/test/wsdl-parse-test.js
@@ -32,8 +32,8 @@ describe(__filename, function() {
       var complexType = schema.complexTypes['ContactMedium'];
       var doc = complexType.children[0].children[0];
       assert.equal(doc.name, 'documentation');
-      assert.equal(doc.$value, 'Defines the method of contact to reach a ' +
-        'party (in\n                their specified role)');
+      assert.equal(doc.$value.replace('\r', ''), 'Defines the method of ' +
+        'contact to reach a party (in\n                their specified role)');
       // If we get here then we succeeded
       done(err);
     });


### PR DESCRIPTION
### Description

I had a problem to execute the tests. On my windows system, I get a '\r\n' instead the expected '\n'. I think it's a Win-Linux-line-feed-thing...

### Checklist
- [x] New tests added or existing tests modified to cover all changes