### PR TITLE
Describe elements of operation part when it is a complex type

### DIFF
--- a/src/parser/wsdl/operation.js
+++ b/src/parser/wsdl/operation.js
@@ -13,6 +13,7 @@ var TypeDescriptor = descriptor.TypeDescriptor;
 var QName = require('../qname');
 var helper = require('../helper');
 var SimpleType = require('../xsd/simpleType');
+var ComplexType = require('../xsd/complexType');
 
 var assert = require('assert');
 
@@ -178,6 +179,12 @@ class Operation extends WSDLElement {
               }
               let element = new descriptor.ElementDescriptor(
                 new QName(nsURI, p), type, 'unqualified', false);
+              if (part.type instanceof ComplexType) {
+                let typeDescription = part.type.describe(definitions);
+                for (let e in typeDescription.elements) {
+                  element.addElement(typeDescription.elements[e]);
+                }
+              }
               inputParts.addElement(element);
             } else if (part.element) {
               var elementDescriptor = part.element.describe(definitions);
@@ -198,6 +205,12 @@ class Operation extends WSDLElement {
               }
               let element = new descriptor.ElementDescriptor(
                 new QName(nsURI, p), type, 'unqualified', false);
+              if (part.type instanceof ComplexType) {
+                let typeDescription = part.type.describe(definitions);
+                for (let e in typeDescription.elements) {
+                  element.addElement(typeDescription.elements[e]);
+                }
+              }
               outputParts.addElement(element);
             } else if (part.element) {
               let elementDescriptor = part.element.describe(definitions);

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -214,6 +214,30 @@ describe('wsdl-tests', function() {
         done();
       });
     });
+
+    it('should describe the part when it is a complex type', function(done) {
+      openWSDL(path.resolve(__dirname, 'wsdl/complex_type_part.wsdl'), function(
+        err,
+        def
+      ) {
+        var operation = def.definitions.bindings.ITPAPIPOSbinding.operations.GetArticlesInfo;
+        var operationDesc = operation.describe(def);
+
+        assert(operationDesc.input.body.elements);
+
+        assert.equal(operationDesc.input.body.elements[0].qname.name, 'Request');
+        // Check that the element with name 'Password' is inside the Request element description.
+        assert.equal(operationDesc.input.body.elements[0].elements[0].qname.name, 'Password');
+
+        assert(operationDesc.output.body.elements);
+
+        // Check that the element with name 'ReturnCode' is inside the return element description.
+        assert.equal(operationDesc.output.body.elements[0].qname.name, 'return');
+        assert.equal(operationDesc.output.body.elements[0].elements[0].qname.name, 'ReturnCode');
+
+        done();
+      });
+    });
   });
 });
 

--- a/test/wsdl/complex_type_part.wsdl
+++ b/test/wsdl/complex_type_part.wsdl
@@ -1,0 +1,106 @@
+<?xml version="1.0"?>
+<definitions xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:xs="http://www.w3.org/2001/XMLSchema" name="ITPAPIPOSservice" targetNamespace="http://tpapipos.com/" xmlns:tns="http://tpapipos.com/" xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:soapenc="http://schemas.xmlsoap.org/soap/encoding/" xmlns:mime="http://schemas.xmlsoap.org/wsdl/mime/" xmlns:ns1="urn:TPAPIPosTypesU" xmlns:ns2="urn:TPAPIPosIntfU">
+  <types>
+    <xs:schema targetNamespace="urn:TPAPIPosTypesU" xmlns="urn:TPAPIPosTypesU">
+      <xs:complexType name="TTPApiPosRequest">
+        <xs:sequence>
+          <xs:element name="Password" type="xs:string"/>
+          <xs:element name="UserName" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="TTPApiPosResponse">
+        <xs:sequence>
+          <xs:element name="ReturnCode" type="xs:int"/>
+          <xs:element name="ReturnMessage" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="TArticleInfoArray">
+        <xs:complexContent>
+          <xs:restriction base="soapenc:Array">
+            <xs:sequence>
+                <!--<xs:element name="Articles" type="ns1:TArticleInfo" 
+                minOccurs="0" maxOccurs="unbounded"/> -->
+            </xs:sequence>
+            <xs:attribute ref="soapenc:arrayType" n1:arrayType="ns1:TArticleInfo[]" xmlns:n1="http://schemas.xmlsoap.org/wsdl/"/>
+          </xs:restriction>
+        </xs:complexContent>
+      </xs:complexType>
+      <xs:complexType name="TArticleInfo">
+        <xs:sequence>
+          <xs:element name="ArticleId" type="xs:long"/>
+          <xs:element name="ArticleName" type="xs:string"/>
+          <xs:element name="ArticleNumber" type="xs:int"/>
+          <xs:element name="Available" type="ns1:TInt64Array"/>
+          <xs:element name="DepartmentId" type="xs:long"/>
+          <xs:element name="FreeOption" type="xs:long"/>
+          <xs:element name="Options" type="ns1:TInt64Array"/>
+          <xs:element name="IsMenu" type="xs:boolean"/>
+          <xs:element name="IsManualPrice" type="xs:boolean"/>
+          <xs:element name="IsActive" type="xs:boolean"/>
+          <xs:element name="Promo" type="xs:boolean"/>
+          <xs:element name="HqId" type="xs:string"/>
+        </xs:sequence>
+      </xs:complexType>
+      <xs:complexType name="TInt64Array">
+        <xs:complexContent>
+          <xs:restriction base="soapenc:Array">
+            <xs:sequence/>
+            <xs:attribute ref="soapenc:arrayType" n1:arrayType="xs:long[]" xmlns:n1="http://schemas.xmlsoap.org/wsdl/"/>
+          </xs:restriction>
+        </xs:complexContent>
+      </xs:complexType>
+    </xs:schema>
+    <xs:schema targetNamespace="urn:TPAPIPosIntfU" xmlns="urn:TPAPIPosIntfU">
+      <xs:complexType name="TGetArticlesInfoRequest">
+        <xs:complexContent>
+          <xs:extension base="ns1:TTPApiPosRequest">
+            <xs:sequence>
+              <xs:element name="ArticleId" type="xs:long"/>
+              <xs:element name="SalesAreaId" type="xs:long"/>
+              <xs:element name="GetInactive" type="xs:boolean"/>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+      <xs:complexType name="TGetArticlesInfoResponse">
+        <xs:complexContent>
+          <xs:extension base="ns1:TTPApiPosResponse">
+            <xs:sequence>
+              <xs:element name="Articles" type="ns1:TArticleInfoArray"/>
+            </xs:sequence>
+          </xs:extension>
+        </xs:complexContent>
+      </xs:complexType>
+    </xs:schema>
+  </types>
+  <message name="GetArticlesInfo2Request">
+    <part name="Request" type="ns2:TGetArticlesInfoRequest"/>
+  </message>
+  <message name="GetArticlesInfo2Response">
+    <part name="return" type="ns2:TGetArticlesInfoResponse"/>
+  </message>
+  <portType name="ITPAPIPOS">
+    <operation name="GetArticlesInfo">
+      <input message="tns:GetArticlesInfo2Request"/>
+      <output message="tns:GetArticlesInfo2Response"/>
+    </operation>
+  </portType>
+  <binding name="ITPAPIPOSbinding" type="tns:ITPAPIPOS">
+    <soap:binding style="rpc" transport="http://schemas.xmlsoap.org/soap/http"/>
+    <operation name="GetArticlesInfo">
+      <soap:operation soapAction="urn:TPAPIPosIntfU-ITPAPIPOS#GetArticlesInfo" style="rpc"/>
+      <input>
+        <soap:body use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:TPAPIPosIntfU-ITPAPIPOS"/>
+      </input>
+      <output>
+        <soap:body use="encoded" encodingStyle="http://schemas.xmlsoap.org/soap/encoding/" namespace="urn:TPAPIPosIntfU-ITPAPIPOS"/>
+      </output>
+    </operation>
+  </binding>
+  <service name="ITPAPIPOSservice">
+    <port name="ITPAPIPOSPort" binding="tns:ITPAPIPOSbinding">
+      <soap:address location="http://213.125.56.34:3063/soap/ITPAPIPOS"/>
+    </port>
+  </service>
+</definitions>
+


### PR DESCRIPTION
### Description
When a message part references a complex type the elements of the complex type should be in the description.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
