### PR TITLE
Keep original xml in request

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -104,6 +104,7 @@ class Server extends Base {
           if (typeof self.log === 'function') {
             self.log('received', xml);
           }
+          req.originalXml = xml;
           self._process(xml, req, function(result, statusCode) {
             if (statusCode) {
               res.statusCode = statusCode;


### PR DESCRIPTION
### Description
In order to use the original data later, the original XML is stored in
the request.
