### PR TITLE
Remove unnecessary files from npm packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,7 @@
 .idea
 test
 .travis.yml
+coverage
+.nyc_output
+.github
+.vscode


### PR DESCRIPTION
Update `.npmignore` to avoid shipping garbage files to consumers on npm

The largest folder is `coverage`, sitting at 1.8MB.

```
$ du -h -d1 strong-soap/  | sort -h
0       strong-soap/node_modules
4.0K    strong-soap/.vscode
8.0K    strong-soap/.github
60K     strong-soap/example
72K     strong-soap/xsds
120K    strong-soap/intl
432K    strong-soap/lib
440K    strong-soap/src
476K    strong-soap/.nyc_output
1.8M    strong-soap/coverage
3.5M    strong-soap/
```
