### PR TITLE
Allow non strings tobe nillable

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -878,7 +878,7 @@ function toXmlDateTime(date) {
 }
 
 function toXmlDateOrTime(descriptor, val) {
-  if (!descriptor || !descriptor.type) return val;
+  if (!descriptor || !descriptor.type || val === null) return val;
   if (descriptor.type.name === 'date') {
     val = toXmlDate(val);
   } else if (descriptor.type.name === 'time') {

--- a/test/request-response-samples/Dummy__should_parse_nil/common.xsd
+++ b/test/request-response-samples/Dummy__should_parse_nil/common.xsd
@@ -22,7 +22,8 @@
         <xs:sequence>
             <xs:element name="DummyIntFilter" type="xs:string" minOccurs="0"/>
             <xs:element name="DummyStringFilter" type="xs:string" nillable="true" minOccurs="0"/>
-        </xs:sequence>
+			<xs:element name="DummyDateFilter" type="xs:date" nillable="true" minOccurs="0"/>
+		</xs:sequence>
     </xs:complexType>
 </xs:schema>
 

--- a/test/request-response-samples/Dummy__should_parse_nil/request.json
+++ b/test/request-response-samples/Dummy__should_parse_nil/request.json
@@ -2,7 +2,8 @@
   "DummyRequest": {
       "DummyField1": "Humpty",
       "DummyFilter": {
-        "DummyStringFilter": null
+        "DummyStringFilter": null,
+        "DummyDateFilter": null
       }
   }
 }

--- a/test/request-response-samples/Dummy__should_parse_nil/request.xml
+++ b/test/request-response-samples/Dummy__should_parse_nil/request.xml
@@ -6,6 +6,7 @@
             <ns1:DummyField1>Humpty</ns1:DummyField1>
             <ns1:DummyFilter>
                  <ns2:DummyStringFilter xmlns:ns2="http://www.Dummy.com/Common/Types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
+                 <ns2:DummyDateFilter xmlns:ns2="http://www.Dummy.com/Common/Types" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:nil="true"/>
             </ns1:DummyFilter>
         </ns1:DummyRequest>
 </soap:Body>


### PR DESCRIPTION
### Description
Fixes issue with non-string fields (i.e. dates) not being able to be nilled.

#### Related issues
#263 
<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x ] New tests added or existing tests modified to cover all changes
- [x ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
