### PR TITLE
Handle restrictions in anonymous simple types

### DIFF
--- a/src/parser/xmlHandler.js
+++ b/src/parser/xmlHandler.js
@@ -123,7 +123,12 @@ class XMLHandler {
         if (this.options.enforceRestrictions && descriptor.type) {
           const schema = this.schemas[descriptor.type.nsURI];
           if (schema) {
-            const type = schema.simpleTypes[descriptor.type.name];
+            let type = schema.simpleTypes[descriptor.type.name];
+            // if type not available in global schema
+            // , check if it is embedded in descriptor as an anonymous type
+            if (!type && descriptor.type.anonymous) {
+              type = descriptor.type.anonymous;
+            }
             if (type) {
               const restriction = type.restriction;
               if (restriction) {

--- a/src/parser/xsd/element.js
+++ b/src/parser/xsd/element.js
@@ -82,8 +82,21 @@ class Element extends XSDElement {
           }
           break;
         } else if (child instanceof SimpleType) {
+          // name of the parent element is the anonymous type's name
+          child.$name = this.$name;
+          let typeQName = child.getQName();
+          // regenerate descriptor with new type qname
+          descriptor = this.descriptor =
+            new XSDElement.ElementDescriptor(qname, typeQName, form, isMany);
           descriptor.isSimple = true;
-          descriptor.jsType = child.jsType;
+          if (child.type && child.type.jsType) {
+            descriptor.jsType = child.type.jsType;
+          } else if (child.jsType) {
+            descriptor.jsType = child.jsType;
+          }
+          descriptor.type = typeQName;
+          // embed anonymous type inside the descriptor
+          descriptor.type.anonymous = child;
         }
       }
     }

--- a/src/parser/xsd/restriction.js
+++ b/src/parser/xsd/restriction.js
@@ -107,6 +107,12 @@ class Restriction extends XSDElement {
       } else if (typeof this.base.jsType === 'function' && this.base.jsType !== Date && this.base.jsType !== Number) {
         val = this.base.jsType(val);
       }
+
+      if(this.base.jsType === Number) {
+        if(isNaN(val)){
+          violations.push('value is not a number (' + val + ')');
+        }
+      }
     }
 
     if (this.minExclusive !== undefined) {

--- a/src/parser/xsd/simpleType.js
+++ b/src/parser/xsd/simpleType.js
@@ -37,8 +37,8 @@ class SimpleType extends XSDElement {
     if (this.restriction) {
       this.restriction.postProcess(definitions);
       if (this.restriction.base) {
-        // Use the base type
-        this.type = this.restriction.base.type;
+        // Use the restriction base for more information on the xs:type
+        this.type = this.restriction.base;
       }
     } else if (this.list) {
       this.list.postProcess(definitions);

--- a/test/client-restrictions-test.js
+++ b/test/client-restrictions-test.js
@@ -107,6 +107,24 @@ describe('SOAP Client', function() {
       }, 'http://' + hostname + ":" + server.address().port);
     });
 
+    it('should throw error if the type doesn\'t match its restriction of number', function (done) {
+      soap.createClient(__dirname + '/wsdl/restrictions.wsdl', { enforceRestrictions: true }, function (err, client) {
+        assert.equal(err, null);
+        try {
+          client.TestRestrictions({
+            RestrictionRequest: {
+              minExclusive: "five"
+            }
+          }, function () {
+            done('It should have thrown error');
+          });
+        } catch (err) {
+          assert.equal(err.message, 'The field MinExclusiveType cannot have value five due to the violations: ["value is not a number (five)"]');
+          done();
+        }
+      }, 'http://' + hostname + ":" + server.address().port);
+    });
+
     it('should throw if the minInclusive doesn\'t match its restriction', function (done) {
       soap.createClient(__dirname + '/wsdl/restrictions.wsdl', { enforceRestrictions: true }, function (err, client) {
         assert.equal(err, null);
@@ -356,6 +374,24 @@ describe('SOAP Client', function() {
       }, 'http://' + hostname + ":" + server.address().port);
     });
 
+    it('should throw if the maxLength doesn\'t match its restriction in an anonymous simple type', function (done) {
+      soap.createClient(__dirname + '/wsdl/restriction_anonymous_types.wsdl', { enforceRestrictions: true }, function (err, client) {
+        assert.equal(err, null);
+        try {
+          client.TestRestrictions({
+            RestrictionRequest: {
+              elementWithAnonymousType: 'abcdef'
+            }
+          }, function () {
+            done('It should have thrown error');
+          });
+        } catch (err) {
+          assert.equal(err.message, 'The field elementWithAnonymousType cannot have value abcdef due to the violations: ["length is bigger than maxLength (6 > 3)"]');
+          done();
+        }
+
+      }, 'http://' + hostname + ":" + server.address().port);
+    });
   });
 
 });

--- a/test/wsdl-test.js
+++ b/test/wsdl-test.js
@@ -187,6 +187,36 @@ describe('wsdl-tests', function() {
       });
     });
 
+    it('should return type data about anonymous simple types within elements', function(done) {
+      openWSDL(path.resolve(__dirname, 'wsdl/restriction_anonymous_types.wsdl'), function(
+        err,
+        def
+      ) {
+        var operation = def.definitions.bindings.RestrictionsBinding.operations.TestRestrictions;
+        var operationDesc = operation.describe(def);
+  
+        var requestElements = operationDesc.input.body.elements[0].elements;
+
+        // second element in the operation request is an element with anonymous type
+        // , hence pick array[1]
+        let elementWithAnonymousType = requestElements[1];
+        assert(elementWithAnonymousType.isSimple);
+        assert.equal(elementWithAnonymousType.qname.name, "elementWithAnonymousType");
+        // anonymous types have same name as parent element
+        assert.equal(elementWithAnonymousType.type.name, elementWithAnonymousType.qname.name);
+        // Check if anonymous type restriction is embedded in the parent element
+        assert.equal(elementWithAnonymousType.type.anonymous.name, "simpleType");
+        assert.equal(elementWithAnonymousType.type.anonymous.type.$name, "string");
+
+        // also check element with type for regression
+        assert.equal(requestElements[0].qname.name, "stringElement");
+        assert(requestElements[0].isSimple);
+        assert.equal(requestElements[0].type.name, "string");
+
+        done();
+      });
+    });
+
     it('should map isMany values correctly', function(done) {
       openWSDL(path.resolve(__dirname, 'wsdl/marketo.wsdl'), function(
         err,

--- a/test/wsdl/restriction_anonymous_types.wsdl
+++ b/test/wsdl/restriction_anonymous_types.wsdl
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+                  xmlns:tns="http://www.Restrictions.com"
+                  xmlns:n="http://www.Restriction.com/Types"
+                  xmlns:ns="http://schemas.xmlsoap.org/soap/encoding/"
+                  targetNamespace="http://www.Restrictions.com">
+    <wsdl:types>
+      <xsd:schema xmlns:tns="http://www.Restriction.com/Types"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.Restriction.com/Types"
+           elementFormDefault="qualified" attributeFormDefault="unqualified">
+        <xsd:complexType name="RestrictionRequestType">
+          <xsd:all>
+            <xsd:element type="xsd:string" name="stringElement"/>
+            <xsd:element name="elementWithAnonymousType">
+              <xsd:simpleType>
+                <xsd:restriction base="xsd:string">
+                  <xsd:maxLength value="3"/>
+                </xsd:restriction>
+              </xsd:simpleType>
+            </xsd:element>
+          </xsd:all>
+        </xsd:complexType>
+        <xs:element name="RestrictionRequest" type="RestrictionRequestType"/>
+        <xs:element name="RestrictionResponse" type="RestrictionRequestType"/>
+      </xsd:schema>
+    </wsdl:types>
+    <wsdl:message name="RestrictionsRequest">
+        <wsdl:part name="RestrictionsRequest" element="n:RestrictionRequest"/>
+    </wsdl:message>
+    <wsdl:message name="RestrictionsResponse">
+        <wsdl:part name="RestrictionsResponse" element="n:RestrictionResponse"/>
+    </wsdl:message>
+    <wsdl:portType name="RestrictionsPortType">
+        <wsdl:operation name="TestRestrictions">
+            <wsdl:input message="tns:RestrictionsRequest"/>
+            <wsdl:output message="tns:RestrictionsResponse"/>
+        </wsdl:operation>
+    </wsdl:portType>
+    <wsdl:binding name="RestrictionsBinding" type="tns:RestrictionsPortType">
+        <soap:binding style="document"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="TestRestrictions">
+            <soap:operation soapAction="http://www.Restrictions.com#Restrictions"
+                            style="document"/>
+            <wsdl:input>
+                <soap:body use="literal"/>
+            </wsdl:input>
+            <wsdl:output>
+                <soap:body use="literal"/>
+            </wsdl:output>
+        </wsdl:operation>
+    </wsdl:binding>
+    <wsdl:service name="RestrictionsService">
+        <wsdl:port name="RestrictionsPortType" binding="tns:RestrictionsBinding">
+            <soap:address location="http://www.Restrictions.com/"/>
+        </wsdl:port>
+    </wsdl:service>
+</wsdl:definitions>

--- a/test/wsdl/restriction_types.xsd
+++ b/test/wsdl/restriction_types.xsd
@@ -99,4 +99,3 @@
     <xs:element name="RestrictionRequest" type="RestrictionRequestType"/>
     <xs:element name="RestrictionResponse" type="RestrictionRequestType"/>
 </xs:schema>
-


### PR DESCRIPTION
### Description
When specifying the type of an element in an xsd, 2 possible ways are:
1) Specifying the type in the element
```
            <xsd:element type="xsd:string" name="elementWithType"/>
```
and 
2) Specifying a restriction via a simple type
```
            <xsd:element name="elementWithSimpleType">
              <xsd:simpleType>
                <xsd:restriction base="xsd:string">
                  <xsd:maxLength value="3"/>
                </xsd:restriction>
              </xsd:simpleType>
            </xsd:element>
```
When inspecting the properties of an element using a strong-soap feature like `operation.describe(wsdlDef);` it is possible to find out the type of the first type of element, but not the 2nd type (specified via a restriction).

This PR ensure that this information is set on the describe of the simple type.

A new test has been added to show that the type information is present and there are existing tests under https://github.com/strongloop/strong-soap/blob/master/test/client-restrictions-test.js which should show that this hasn't changed the way the client works when dealing with restrictions. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->


### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
