### PR TITLE
feat add(client) accepts soapHeaders property upon method invocation

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -122,7 +122,9 @@ class Client extends Base {
       soapAction,
       headers = {
         'Content-Type': 'text/xml; charset=utf-8'
-      };
+      },
+      dynamicSoapHeaderProperty = ['soapHeaders'],
+      dynamicSoapHeaders = {};
 
     debug('client request. operation: %s args: %j options: %j extraHeaders: %j', operation.name, args, options, extraHeaders);
 
@@ -155,7 +157,15 @@ class Client extends Base {
     options = options || {};
     debugSensitive('client request. options: %j', options);
 
-    //Add extra headers
+    dynamicSoapHeaders = _.merge(_.pick(extraHeaders, dynamicSoapHeaderProperty),
+	                       _.pick(options, dynamicSoapHeaderProperty));
+
+    debug('Soap xml payload extra headers: %j', dynamicSoapHeaders);
+
+    extraHeaders = _.omit(extraHeaders, dynamicSoapHeaderProperty);
+    options = _.omit(options, dynamicSoapHeaderProperty);
+
+    //Add extra headers to http request
     for (var header in this.httpHeaders) {
       headers[header] = this.httpHeaders[header];
     }
@@ -163,6 +173,14 @@ class Client extends Base {
       headers[attr] = extraHeaders[attr];
     }
 
+    // Clear and Add new SOAP Headers
+     if (!_.isEmpty(dynamicSoapHeaders)) {             
+        this.clearSoapHeaders();
+        for (var attr in dynamicSoapHeaders) {
+           this.addSoapHeader(dynamicSoapHeaders[attr]);
+        }
+    }
+    
     debug('client request. headers: %j', headers);
 
     //Unlike other security objects, NTLMSecurity is passed in through client options rather than client.setSecurity(ntlmSecurity) as some

--- a/test/client-test.js
+++ b/test/client-test.js
@@ -314,6 +314,62 @@ describe('SOAP Client', function() {
       }, 'http://' + hostname + ':' + server.address().port  );
     });
 
+    it('should add soap headers from options', function (done) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        assert.ok(client);
+        assert.ok(client.getSoapHeaders().length === 0);
+        var soapheader = {
+          'esnext': false,
+          'moz': true,
+          'boss': true,
+          'node': true,
+          'validthis': true,
+          'globals': {
+            'EventEmitter': true,
+            'Promise': true
+          }
+        };      
+        var lastRequest = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Header>\n"
+        + "    <esnext>false</esnext>\n    <moz>true</moz>\n    <boss>true</boss>\n    <node>true</node>\n    <validthis>true</validthis>\n    <globals>\n      <EventEmitter>true</EventEmitter>\n      <Promise>true</Promise>\n    </globals>\n"
+        + "  </soap:Header>\n  <soap:Body/>\n</soap:Envelope>";
+        client.MyOperation({}, function(err, result) {
+          //using lastRequest instead of lastRequestHeaders() since this doesn't contain soap header which this test case needs to test.
+          assert.equal(client.lastRequest, lastRequest);
+          done();
+        }, {
+          soapHeaders: soapheader
+        });
+      }, 'http://' + hostname + ':' + server.address().port  );
+    });
+
+    it('should add soap headers from extraHeaders', function (done) {
+      soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
+        assert.ok(client);
+        assert.ok(client.getSoapHeaders().length === 0);
+        var soapheader = {
+          'esnext': false,
+          'moz': true,
+          'boss': true,
+          'node': true,
+          'validthis': true,
+          'globals': {
+            'EventEmitter': true,
+            'Promise': true
+          }
+        };      
+        var lastRequest = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">\n  <soap:Header>\n"
+        + "    <esnext>false</esnext>\n    <moz>true</moz>\n    <boss>true</boss>\n    <node>true</node>\n    <validthis>true</validthis>\n    <globals>\n      <EventEmitter>true</EventEmitter>\n      <Promise>true</Promise>\n    </globals>\n"
+        + "  </soap:Header>\n  <soap:Body/>\n</soap:Envelope>";
+        client.MyOperation({}, function(err, result) {
+          //using lastRequest instead of lastRequestHeaders() since this doesn't contain soap header which this test case needs to test.
+          assert.equal(client.lastRequest, lastRequest);
+          done();
+        }, undefined, {
+          soapHeaders: soapheader
+        });
+      }, 'http://' + hostname + ':' + server.address().port  );
+    });
+
     it('should add soap headers', function (done) {
       soap.createClient(__dirname + '/wsdl/default_namespace.wsdl', function (err, client) {
         assert.ok(client);

--- a/test/server-test.js
+++ b/test/server-test.js
@@ -347,6 +347,26 @@ describe('SOAP Server', function() {
     });
   });
 
+  it('should emit \'headers\' event from options', function(done) {
+    test.soapServer.on('headers', function headersManager(headers, methodName) {
+      assert.equal(methodName, 'GetLastTradePrice');
+      headers.SomeToken = 0;
+    });
+    soap.createClient(test.baseUrl + '/stockquote?wsdl', function(err, client) {
+      assert.ok(!err);
+     // client.addSoapHeader('<SomeToken>123.45</SomeToken>');
+      client.GetLastTradePrice({TradePriceRequest: { tickerSymbol: 'AAPL'}}, function(err, result) {
+        assert.ok(!err);
+        assert.equal(0, parseFloat(result.price));
+        done();
+      }, {
+        soapHeaders: { 
+          SomeToken: 123.45
+        }
+      });
+    });
+  });
+
   it('should not emit the \'headers\' event when there are no headers', function(done) {
     test.soapServer.on('headers', function headersManager(headers, methodName) {
       assert.ok(false);


### PR DESCRIPTION
### Description
This PR adds the capability for the internal `_invoke`  method on `client.js`  to parse and add in a clean way soap Headers at run time. We can the property `soapHeaders` to the `options` and `extraHeaders` parameters of this method and it will add it to the soap Headers before calling the remote method.

This will be very helpful especially for loopback 4 soap connector. We can now add the `json` structure to the second or third parameter of the local method in the service.

#### Related issues
This relates to the issue 

- connect to https://github.com/strongloop/loopback-connector-soap/issues/108

### Checklist

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
