### PR TITLE
bump/xml crypto 2.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6489,12 +6489,12 @@
       "dev": true
     },
     "xml-crypto": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.0.0.tgz",
-      "integrity": "sha512-/a04qr7RpONRZHOxROZ6iIHItdsQQjN3sj8lJkYDDss8tAkEaAs0VrFjb3tlhmS5snQru5lTs9/5ISSMdPDHlg==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.1.tgz",
+      "integrity": "sha512-M+m4+HIJa83lu/CnspQjA7ap8gmanNDxxRjSisU8mPD4bqhxbo5N2bdpvG2WgVYOrPpOIOq55iY8Cz8Ai40IeQ==",
       "requires": {
-        "xmldom": "0.1.27",
-        "xpath": "0.0.27"
+        "xmldom": "0.5.0",
+        "xpath": "0.0.32"
       }
     },
     "xmlbuilder": {
@@ -6503,14 +6503,14 @@
       "integrity": "sha512-OyzrcFLL/nb6fMGHbiRDuPup9ljBycsdCypwuyg5AAHvyWzGfChJpCXMG88AGTIMFhGZ9RccFN1e6lhg3hkwKg=="
     },
     "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha1-1QH5ezvbQDr4757MIFcxh6rawOk="
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
+      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA=="
     },
     "xpath": {
-      "version": "0.0.27",
-      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.27.tgz",
-      "integrity": "sha512-fg03WRxtkCV6ohClePNAECYsmpKKTv5L8y/X3Dn1hQrec3POx2jHZ/0P2qQ6HvsrU1BmeqXcof3NGGueG6LxwQ=="
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "selectn": "^1.0.20",
     "strong-globalize": "^6.0.5",
     "uuid": "^8.3.1",
-    "xml-crypto": "^2.0.0",
+    "xml-crypto": "^2.1.1",
     "xmlbuilder": "^10.1.1"
   },
   "repository": {


### PR DESCRIPTION
### Description

bump `xml-crypto` to version `2.1.1` that has `xmldom` version `0.1.27` as dependency that has known security vulnerabilities.

<img width="942" alt="Screenshot 2021-03-24 at 12 33 52" src="https://user-images.githubusercontent.com/9430821/112304008-44fb3500-8c9d-11eb-9b1f-252edab0faea.png">

<img width="931" alt="Screenshot 2021-03-24 at 12 33 59" src="https://user-images.githubusercontent.com/9430821/112304001-43317180-8c9d-11eb-9cb4-64de97954377.png">


### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
