### PR TITLE
add require globalize to fix broken call to g.f()

### DIFF
--- a/soap-stub.js
+++ b/soap-stub.js
@@ -3,6 +3,7 @@
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
 
+var g = require('./lib/globalize');
 var _ = require('lodash');
 
 var aliasedClientStubs = {};


### PR DESCRIPTION
### Description

next try - shortening commit message did not really worked, needed to recreated everthing. 

This PR is a replacement to #313 to have only the commit needed to fix the soap-stub.js file.
It adds the accidentally removed require call to globalize.js to allow the stubs createClient() method to be used again for testing

#### Related issues

- connect to #313
- connect to 8f28d00

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
