### PR TITLE
chore: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2956,19 +2956,10 @@
         "sshpk": "^1.7.0"
       }
     },
-    "httpntlm": {
-      "version": "1.7.6",
-      "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.7.6.tgz",
-      "integrity": "sha1-aZHoNSg2AH1nEBuD247Q+RX5BtA=",
-      "requires": {
-        "httpreq": ">=0.4.22",
-        "underscore": "~1.7.0"
-      }
-    },
-    "httpreq": {
-      "version": "0.4.24",
-      "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
-      "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8="
+    "httpntlm-maa": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/httpntlm-maa/-/httpntlm-maa-2.0.6.tgz",
+      "integrity": "sha512-WuBHAqCwaXZxTNXDprC/AXQ55eWzPJsjPiJFYv2igGXJSu5oSdvuLXaB57dXx/6EyLuvD+Jjouto6UbMh1YkpQ=="
     },
     "human-signals": {
       "version": "1.1.1",
@@ -6117,11 +6108,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "underscore": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
-      "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
-    },
     "unherit": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/unherit/-/unherit-1.1.3.tgz",
@@ -6519,9 +6505,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.1.tgz",
+      "integrity": "sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==",
       "dev": true
     },
     "yamljs": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "compress": "^0.99.0",
     "debug": "^4.1.1",
-    "httpntlm": "^1.7.6",
+    "httpntlm-maa": "^2.0.6",
     "lodash": "^4.17.20",
     "node-rsa": "^1.1.1",
     "request": "^2.72.0",

--- a/src/http.js
+++ b/src/http.js
@@ -9,7 +9,7 @@ var url = require('url');
 var req = require('request');
 var debug = require('debug')('strong-soap:http');
 var debugSensitive = require('debug')('strong-soap:http:sensitive');
-var httpntlm = require('httpntlm');
+var httpntlm = require('httpntlm-maa');
 var uuid = require('uuid').v4;
 
 


### PR DESCRIPTION
### Description
There are 2 changes in this PR:
- Update package-lock.json for `y18n`. The change is generated by running `npm audit fix`.
- replace `httpntlm` with [`httpntlm-maa`](https://github.com/maa105/node-http-ntlm) because of the security vulnerability introduced in one of the dependencies from `httpntlm`. Such vulnerability does not exist in `httpntlm-maa`

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
